### PR TITLE
8 implement forward and previous player controls

### DIFF
--- a/assets/js/hooks/player-syncing.js
+++ b/assets/js/hooks/player-syncing.js
@@ -6,7 +6,7 @@ const onStateChange = hookContext => event => {
     }
     case 0: {
       console.log('ended')
-      hookContext.pushEvent('player_signal_play_next')
+      hookContext.pushEvent('player_signal_video_ended')
       break
     }
     case 1: {

--- a/lib/live_dj/organizer/player.ex
+++ b/lib/live_dj/organizer/player.ex
@@ -1,23 +1,55 @@
 defmodule LiveDj.Organizer.Player do
 
   def get_initial_state do
-    %{state: "stopped", video_id: "", time: 0}
+    %{state: "stopped", video_id: "", time: 0, previous_id: "", next_id: ""}
   end
 
   def get_controls_state(%{video_id: "", state: _}) do
-    %{play_button_state: "disabled", pause_button_state: "disabled"}
+    %{play_button_state: "disabled", pause_button_state: "disabled", previous_button_state: "disabled", next_button_state: "disabled"}
   end
 
-  def get_controls_state(%{video_id: _, state: "paused"}) do
-    %{play_button_state: "", pause_button_state: "disabled"}
+  def get_controls_state(%{video_id: _, state: "paused", previous_id: "", next_id: ""}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "disabled", next_button_state: "disabled"}
   end
 
-  def get_controls_state(%{video_id: _, state: "stopped"}) do
-    %{play_button_state: "", pause_button_state: "disabled"}
+  def get_controls_state(%{video_id: _, state: "paused", previous_id: _, next_id: ""}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "", next_button_state: "disabled"}
   end
 
-  def get_controls_state(%{video_id: _, state: "playing"}) do
-    %{play_button_state: "disabled", pause_button_state: ""}
+  def get_controls_state(%{video_id: _, state: "paused", previous_id: "", next_id: _}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "disabled", next_button_state: ""}
+  end
+
+  def get_controls_state(%{video_id: _, state: "paused", previous_id: _, next_id: _}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "", next_button_state: ""}
+  end
+
+  def get_controls_state(%{video_id: _, state: "stopped", previous_id: "", next_id: ""}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "disabled", next_button_state: "disabled"}
+  end
+
+  def get_controls_state(%{video_id: _, state: "stopped", previous_id: "", next_id: _}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "disabled", next_button_state: ""}
+  end
+
+  def get_controls_state(%{video_id: _, state: "stopped", previous_id: _, next_id: ""}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "", next_button_state: "disabled"}
+  end
+
+  def get_controls_state(%{video_id: _, state: "stopped", previous_id: _, next_id: _}) do
+    %{play_button_state: "", pause_button_state: "disabled", previous_button_state: "", next_button_state: ""}
+  end
+
+  def get_controls_state(%{video_id: _, state: "playing", previous_id: "", next_id: _}) do
+    %{play_button_state: "disabled", pause_button_state: "", previous_button_state: "disabled", next_button_state: ""}
+  end
+
+  def get_controls_state(%{video_id: _, state: "playing", previous_id: _, next_id: ""}) do
+    %{play_button_state: "disabled", pause_button_state: "", previous_button_state: "", next_button_state: "disabled"}
+  end
+
+  def get_controls_state(%{video_id: _, state: "playing", previous_id: _, next_id: _}) do
+    %{play_button_state: "disabled", pause_button_state: "", previous_button_state: "", next_button_state: ""}
   end
 
   def update(player, props) do

--- a/lib/live_dj/organizer/queue.ex
+++ b/lib/live_dj/organizer/queue.ex
@@ -26,4 +26,11 @@ defmodule LiveDj.Organizer.Queue do
     end
   end
 
+  def get_next_video(video_queue, current_video_id) do
+    Enum.find(video_queue, fn video -> video.previous == current_video_id end)
+  end
+
+  def get_previous_video(video_queue, current_video_id) do
+    Enum.find(video_queue, fn video -> video.next == current_video_id end)
+  end
 end

--- a/lib/live_dj_web/live/room/show_live.ex
+++ b/lib/live_dj_web/live/room/show_live.ex
@@ -235,7 +235,7 @@ defmodule LiveDjWeb.Room.ShowLive do
     {:noreply, socket}
   end
 
-  def handle_event("player_signal_play_next", _params, socket) do
+  def handle_event("player_signal_video_ended", _params, socket) do
     %{video_queue: video_queue, player: player} = socket.assigns
     %{video_id: current_video_id} = player
 

--- a/lib/live_dj_web/live/room/show_live.html.leex
+++ b/lib/live_dj_web/live/room/show_live.html.leex
@@ -2,28 +2,48 @@
 
   <div class="row section-container">
     <div class="column">
+      <%= if @player_controls.previous_button_state == "disabled" do %>
+        <a class="disabled">
+          <i class="fas fa-step-backward"></i>
+        </a>
+      <% else %>
+        <a phx-click="player_signal_play_previous">
+          <i class="fas fa-step-backward clickeable"></i>
+        </a>
+      <% end %>
+
       <%= if @player_controls.play_button_state == "disabled" &&
              @player_controls.pause_button_state == "disabled" do%>
         <a>
           <i class="fas fa-spinner rotating"></i>
         </a>
       <% else %>
-      <%= if @player.state == "paused" || @player.state == "stopped" do %>
-        <a
-          <%= @player_controls.play_button_state %>
-          phx-click="player_signal_playing"
-        >
-          <i class="fas fa-play-circle clickeable"></i>
-        </a>
+        <%= if @player.state == "paused" || @player.state == "stopped" do %>
+          <a
+            <%= @player_controls.play_button_state %>
+            phx-click="player_signal_playing"
+          >
+            <i class="fas fa-play-circle clickeable"></i>
+          </a>
+        <% end %>
+        <%= if @player.state == "playing" do %>
+          <a
+            <%= @player_controls.pause_button_state %>
+            phx-click="player_signal_paused"
+          >
+            <i class="fas fa-pause-circle clickeable"></i>
+          </a>
+        <% end %>
       <% end %>
-      <%= if @player.state == "playing" do %>
-        <a
-          <%= @player_controls.pause_button_state %>
-          phx-click="player_signal_paused"
-        >
-          <i class="fas fa-pause-circle clickeable"></i>
+
+      <%= if @player_controls.next_button_state == "disabled" do %>
+        <a class="disabled">
+          <i class="fas fa-step-forward"></i>
         </a>
-      <% end %>
+      <% else %>
+        <a phx-click="player_signal_play_next">
+          <i class="fas fa-step-forward clickeable"></i>
+        </a>
       <% end %>
     </div>
     <div class="column">


### PR DESCRIPTION
This PR provides:

+ Ability to move throw tracks, choosing the next or the previous ones
+ Functions refactor to the Queue module
+ UI changes with new player controls: `play backwards` and `play forward`

Closes #8 