### PR TITLE
:computer: Video tracks automatically scrolls on receive_player_state…

### DIFF
--- a/assets/js/hooks/player-syncing.js
+++ b/assets/js/hooks/player-syncing.js
@@ -66,6 +66,9 @@ const PlayerSyncing = initPlayer => ({
     })
 
     this.handleEvent('receive_player_state', ({shouldPlay, time, videoId}) => {
+      const selector = `[phx-value-video_id="${videoId}"`
+      const videoElement = document.querySelector(selector)
+      videoElement && videoElement.scrollIntoView({behavior: "smooth"})
       player.loadVideoById({
         videoId,
         startSeconds: time


### PR DESCRIPTION
This PR provides:

+ Tracks automatically become visible in the queue when they are being played

Closes #57 