### PR TITLE
Server-authoritative playback clock and playlist auto-advance

### DIFF
--- a/lib/livedj/sessions.ex
+++ b/lib/livedj/sessions.ex
@@ -20,7 +20,8 @@ defmodule Livedj.Sessions do
     PlaylistServer,
     PlaylistSupervisor,
     Room,
-    Supervisor
+    Supervisor,
+    VideoDuration
   }
 
   alias Livedj.Sessions.Exceptions.SessionRoomError
@@ -114,9 +115,8 @@ defmodule Livedj.Sessions do
     {:ok, media_list} = Playlist.get(room_id)
 
     if length(media_list) == 1 do
-      {:ok, %Player{} = player} = Player.load_media(room_id, media, seek_to: 0)
-
-      :ok = Channels.broadcast_player_load_media!(room_id, player)
+      {:ok, player} = load_player_media(room_id, media, seek_to: 0)
+      :ok = broadcast_player_load_media!(room_id, player)
     end
 
     :ok = Channels.broadcast_playlist_track_added!(room_id, media)
@@ -151,7 +151,7 @@ defmodule Livedj.Sessions do
 
     if media_list == [] do
       {:ok, %Player{} = player} = Player.clear_media(room_id)
-
+      notify_playback_clock_track_loaded(room_id)
       :ok = Channels.broadcast_player_load_media!(room_id, player)
     end
 
@@ -351,7 +351,16 @@ defmodule Livedj.Sessions do
   end
 
   @spec on_track_ended(binary()) :: :ok
-  defp on_track_ended(room_id), do: next_track(room_id)
+  defp on_track_ended(room_id) do
+    case Player.get(room_id) do
+      {:ok, %Player{duration: duration}}
+      when is_integer(duration) and duration > 0 ->
+        :ok
+
+      _else ->
+        next_track(room_id)
+    end
+  end
 
   @doc """
   Given a room id, returns a player.
@@ -383,9 +392,10 @@ defmodule Livedj.Sessions do
     with {:ok, %Player{media_id: media_id}} <- get_player(room_id),
          {:ok, previous_media_id} <- Playlist.get_previous(room_id, media_id),
          {:ok, media} <- Media.get_by_external_id(previous_media_id) do
-      {:ok, %Player{} = player} = Player.load_media(room_id, media, seek_to: 0)
+      {:ok, player} =
+        load_player_media(room_id, media, seek_to: 0, autoplay: true)
 
-      :ok = Channels.broadcast_player_load_media!(room_id, player)
+      :ok = broadcast_player_load_media!(room_id, player)
     else
       _error ->
         :ok
@@ -400,9 +410,10 @@ defmodule Livedj.Sessions do
     with {:ok, %Player{media_id: media_id}} <- get_player(room_id),
          {:ok, next_media_id} <- Playlist.get_next(room_id, media_id),
          {:ok, media} <- Media.get_by_external_id(next_media_id) do
-      {:ok, %Player{} = player} = Player.load_media(room_id, media, seek_to: 0)
+      {:ok, player} =
+        load_player_media(room_id, media, seek_to: 0, autoplay: true)
 
-      :ok = Channels.broadcast_player_load_media!(room_id, player)
+      :ok = broadcast_player_load_media!(room_id, player)
     else
       _error ->
         :ok
@@ -415,9 +426,9 @@ defmodule Livedj.Sessions do
   @spec play_track(Ecto.UUID.t(), String.t()) :: :ok | :error
   def play_track(room_id, selected_media_id) do
     with {:ok, media} <- Media.get_by_external_id(selected_media_id),
-         {:ok, %Player{} = player} <-
-           Player.load_media(room_id, media, seek_to: 0) do
-      :ok = Channels.broadcast_player_load_media!(room_id, player)
+         {:ok, player} <-
+           load_player_media(room_id, media, seek_to: 0, autoplay: true) do
+      :ok = broadcast_player_load_media!(room_id, player)
     else
       _error ->
         :error
@@ -439,18 +450,40 @@ defmodule Livedj.Sessions do
   end
 
   @spec sync_player_position(binary(), Player.t()) :: Player.t()
-  defp sync_player_position(room_id, player) do
-    case PlayerSupervisor.get_child(room_id) do
-      nil ->
-        PlaybackPosition.sync(player)
+  defp sync_player_position(_room_id, player) do
+    PlaybackPosition.sync(player)
+  end
 
-      {_pid, _state} ->
-        case room_id
-             |> ensure_playback_clock_pid!()
-             |> PlaybackClock.sync_player() do
-          {:ok, synced} -> synced
-          _error -> PlaybackPosition.sync(player)
-        end
+  @spec load_player_media(binary(), Media.Video.t(), keyword()) ::
+          {:ok, Player.t()} | {:error, any()}
+  defp load_player_media(room_id, media, opts) do
+    opts =
+      case Keyword.get(opts, :duration) do
+        duration when is_integer(duration) and duration > 0 ->
+          opts
+
+        _else ->
+          case VideoDuration.fetch_seconds(media.external_id) do
+            {:ok, seconds} -> Keyword.put(opts, :duration, seconds)
+            {:error, _error} -> opts
+          end
+      end
+
+    with {:ok, player} <- Player.load_media(room_id, media, opts) do
+      notify_playback_clock_track_loaded(room_id)
+      {:ok, PlaybackPosition.sync(player)}
+    end
+  end
+
+  @spec broadcast_player_load_media!(binary(), Player.t()) :: :ok
+  defp broadcast_player_load_media!(room_id, player),
+    do: Channels.broadcast_player_load_media!(room_id, player)
+
+  @spec notify_playback_clock_track_loaded(binary()) :: :ok
+  defp notify_playback_clock_track_loaded(room_id) do
+    case PlayerSupervisor.get_playback_clock(room_id) do
+      {pid, _} -> PlaybackClock.track_loaded(pid)
+      nil -> :ok
     end
   end
 

--- a/lib/livedj/sessions.ex
+++ b/lib/livedj/sessions.ex
@@ -323,6 +323,27 @@ defmodule Livedj.Sessions do
   end
 
   @doc """
+  Reports that the YouTube player reached the end of the current track.
+
+  Only the room controller (first joined LiveView, or next after disconnect)
+  advances the playlist via `next_track/1`.
+  """
+  @spec report_track_ended(binary()) :: :ok
+  def report_track_ended(room_id) do
+    _response =
+      room_id
+      |> get_player_child_pid!()
+      |> PlayerServer.report_track_ended(
+        on_track_ended: {&on_track_ended/1, [room_id]}
+      )
+
+    :ok
+  end
+
+  @spec on_track_ended(binary()) :: :ok
+  defp on_track_ended(room_id), do: next_track(room_id)
+
+  @doc """
   Given a room id, returns a player.
   """
   @spec get_player(Ecto.UUID.t()) :: {:ok, Player.t()} | {:error, any()}

--- a/lib/livedj/sessions.ex
+++ b/lib/livedj/sessions.ex
@@ -11,6 +11,8 @@ defmodule Livedj.Sessions do
 
   alias Livedj.Sessions.{
     Channels,
+    PlaybackClock,
+    PlaybackPosition,
     Player,
     PlayerServer,
     PlayerSupervisor,
@@ -303,7 +305,11 @@ defmodule Livedj.Sessions do
 
   @spec on_play(binary(), keyword()) :: :ok
   defp on_play(room_id, _opts) do
-    {:ok, %Player{} = player} = Player.play(room_id, [])
+    {:ok, %Player{} = player} =
+      room_id
+      |> ensure_playback_clock_pid!()
+      |> PlaybackClock.play()
+
     :ok = Channels.broadcast_player_play!(room_id, player)
   end
 
@@ -318,7 +324,11 @@ defmodule Livedj.Sessions do
 
   @spec on_pause(binary(), keyword()) :: :ok
   defp on_pause(room_id, opts) do
-    {:ok, %Player{} = player} = Player.pause(room_id, opts)
+    {:ok, %Player{} = player} =
+      room_id
+      |> ensure_playback_clock_pid!()
+      |> PlaybackClock.pause(opts)
+
     :ok = Channels.broadcast_player_pause!(room_id, player)
   end
 
@@ -349,10 +359,12 @@ defmodule Livedj.Sessions do
   @spec get_player(Ecto.UUID.t()) :: {:ok, Player.t()} | {:error, any()}
   def get_player(room_id) do
     case Player.get(room_id) do
-      {:ok, result} = response ->
-        Logger.debug("#{__MODULE__} :: Get player result=#{inspect(result)}")
+      {:ok, player} ->
+        synced = sync_player_position(room_id, player)
 
-        response
+        Logger.debug("#{__MODULE__} :: Get player result=#{inspect(synced)}")
+
+        {:ok, synced}
 
       {:error, error} = e ->
         Logger.error(
@@ -414,6 +426,33 @@ defmodule Livedj.Sessions do
 
   defp get_player_child_pid!(room_id),
     do: PlayerSupervisor.get_child_pid!(room_id)
+
+  @spec ensure_playback_clock_pid!(binary()) :: pid()
+  defp ensure_playback_clock_pid!(room_id) do
+    case PlayerSupervisor.start_playback_clock(room_id) do
+      {:ok, pid} ->
+        pid
+
+      {:error, {:already_started, pid}} when is_pid(pid) ->
+        pid
+    end
+  end
+
+  @spec sync_player_position(binary(), Player.t()) :: Player.t()
+  defp sync_player_position(room_id, player) do
+    case PlayerSupervisor.get_child(room_id) do
+      nil ->
+        PlaybackPosition.sync(player)
+
+      {_pid, _state} ->
+        case room_id
+             |> ensure_playback_clock_pid!()
+             |> PlaybackClock.sync_player() do
+          {:ok, synced} -> synced
+          _error -> PlaybackPosition.sync(player)
+        end
+    end
+  end
 
   # ----------------------------------------------------------------------------
   # Media management

--- a/lib/livedj/sessions/playback_clock.ex
+++ b/lib/livedj/sessions/playback_clock.ex
@@ -1,19 +1,24 @@
 defmodule Livedj.Sessions.PlaybackClock do
   @moduledoc """
-  Per-room GenServer that owns play/pause timing for server-authoritative position.
-
-  Phase 2a: records `played_at` on play, clears it on pause, and exposes synced position.
-  Tick-based end detection is deferred to a later phase.
+  Per-room GenServer that owns play/pause timing, periodic end checks while playing,
+  and advancing the playlist when the server clock reaches track duration.
   """
   use GenServer, restart: :transient
 
+  alias Livedj.Sessions
   alias Livedj.Sessions.{PlaybackPosition, Player}
 
   require Logger
 
   @registry_module Registry.PlaybackClock
+  @tick_interval :timer.seconds(1)
+  @tick_msg :tick
 
-  @type state :: %{id: binary()}
+  @type state :: %{
+          id: binary(),
+          tick_ref: reference() | nil,
+          advancing: boolean()
+        }
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
@@ -29,6 +34,9 @@ defmodule Livedj.Sessions.PlaybackClock do
   @spec sync_player(pid()) :: {:ok, Player.t()} | {:error, any()}
   def sync_player(pid), do: GenServer.call(pid, :sync_player)
 
+  @spec track_loaded(pid()) :: :ok
+  def track_loaded(pid), do: GenServer.cast(pid, :track_loaded)
+
   @spec registry_module() :: module()
   def registry_module, do: @registry_module
 
@@ -41,18 +49,24 @@ defmodule Livedj.Sessions.PlaybackClock do
         "#{__MODULE__} :: Started for room=#{room_id}, pid=#{inspect(self())}"
       )
 
-    {:ok, %{id: room_id}, {:continue, :register}}
+    state = %{id: room_id, tick_ref: nil, advancing: false}
+    {:ok, state, {:continue, :register}}
   end
 
   @impl GenServer
   def handle_continue(:register, %{id: room_id} = state) do
     {:ok, _} = Registry.register(@registry_module, room_id, state)
-    {:noreply, state}
+    {:noreply, state, {:continue, :schedule_tick}}
+  end
+
+  def handle_continue(:schedule_tick, state) do
+    {:noreply, reschedule_tick(state)}
   end
 
   @impl GenServer
-  def handle_call(:play, _from, %{id: room_id} = state) do
+  def handle_call(:play, _from, state) do
     played_at = DateTime.utc_now()
+    room_id = state.id
 
     reply =
       case Player.play(room_id, played_at: played_at) do
@@ -60,11 +74,12 @@ defmodule Livedj.Sessions.PlaybackClock do
         error -> error
       end
 
-    {:reply, reply, state}
+    {:reply, reply, reschedule_tick(%{state | advancing: false})}
   end
 
-  def handle_call({:pause, opts}, _from, %{id: room_id} = state) do
+  def handle_call({:pause, opts}, _from, state) do
     at = Keyword.fetch!(opts, :at)
+    room_id = state.id
 
     reply =
       case Player.pause(room_id, at: at) do
@@ -72,7 +87,7 @@ defmodule Livedj.Sessions.PlaybackClock do
         error -> error
       end
 
-    {:reply, reply, state}
+    {:reply, reply, cancel_tick(%{state | advancing: false})}
   end
 
   def handle_call(:sync_player, _from, %{id: room_id} = state) do
@@ -83,5 +98,98 @@ defmodule Livedj.Sessions.PlaybackClock do
       end
 
     {:reply, reply, state}
+  end
+
+  @impl GenServer
+  def handle_cast(:track_loaded, state) do
+    {:noreply, reschedule_tick(%{state | advancing: false})}
+  end
+
+  def handle_cast(:advance_track, %{id: room_id} = state) do
+    media_before = player_media_id(room_id)
+    :ok = Sessions.next_track(room_id)
+    media_after = player_media_id(room_id)
+
+    state =
+      if media_before == media_after do
+        freeze_at_end(room_id)
+        cancel_tick(%{state | advancing: false})
+      else
+        %{state | advancing: false}
+      end
+
+    {:noreply, state, {:continue, :schedule_tick}}
+  end
+
+  @impl GenServer
+  def handle_info(@tick_msg, %{advancing: true} = state) do
+    {:noreply, reschedule_tick(state)}
+  end
+
+  def handle_info(@tick_msg, %{id: room_id} = state) do
+    state =
+      case Player.get(room_id) do
+        {:ok, player} ->
+          if PlaybackPosition.track_ended?(player) do
+            Logger.debug("#{__MODULE__} :: Track ended for room=#{room_id}")
+            GenServer.cast(self(), :advance_track)
+            %{state | advancing: true}
+          else
+            state
+          end
+
+        {:error, _} ->
+          state
+      end
+
+    {:noreply, reschedule_tick(state)}
+  end
+
+  @spec reschedule_tick(state()) :: state()
+  defp reschedule_tick(state) do
+    state = cancel_tick(state)
+
+    case playing?(state.id) do
+      true ->
+        ref = Process.send_after(self(), @tick_msg, @tick_interval)
+        %{state | tick_ref: ref}
+
+      false ->
+        %{state | tick_ref: nil}
+    end
+  end
+
+  @spec cancel_tick(state()) :: state()
+  defp cancel_tick(%{tick_ref: ref} = state) when is_reference(ref) do
+    _timer_response = Process.cancel_timer(ref)
+    %{state | tick_ref: nil}
+  end
+
+  defp cancel_tick(state), do: state
+
+  @spec playing?(binary()) :: boolean()
+  defp playing?(room_id) do
+    case Player.get(room_id) do
+      {:ok, %Player{state: :playing}} -> true
+      _else -> false
+    end
+  end
+
+  @spec player_media_id(binary()) :: binary() | nil
+  defp player_media_id(room_id) do
+    case Player.get(room_id) do
+      {:ok, %Player{media_id: media_id}} -> media_id
+      _else -> nil
+    end
+  end
+
+  @spec freeze_at_end(binary()) :: :ok
+  defp freeze_at_end(room_id) do
+    with {:ok, %Player{duration: duration}} <- Player.get(room_id),
+         position when is_integer(position) <- duration || 0 do
+      _player_response = Player.pause(room_id, at: position)
+    end
+
+    :ok
   end
 end

--- a/lib/livedj/sessions/playback_clock.ex
+++ b/lib/livedj/sessions/playback_clock.ex
@@ -1,0 +1,87 @@
+defmodule Livedj.Sessions.PlaybackClock do
+  @moduledoc """
+  Per-room GenServer that owns play/pause timing for server-authoritative position.
+
+  Phase 2a: records `played_at` on play, clears it on pause, and exposes synced position.
+  Tick-based end detection is deferred to a later phase.
+  """
+  use GenServer, restart: :transient
+
+  alias Livedj.Sessions.{PlaybackPosition, Player}
+
+  require Logger
+
+  @registry_module Registry.PlaybackClock
+
+  @type state :: %{id: binary()}
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec play(pid()) :: {:ok, Player.t()} | {:error, any()}
+  def play(pid), do: GenServer.call(pid, :play)
+
+  @spec pause(pid(), keyword()) :: {:ok, Player.t()} | {:error, any()}
+  def pause(pid, opts), do: GenServer.call(pid, {:pause, opts})
+
+  @spec sync_player(pid()) :: {:ok, Player.t()} | {:error, any()}
+  def sync_player(pid), do: GenServer.call(pid, :sync_player)
+
+  @spec registry_module() :: module()
+  def registry_module, do: @registry_module
+
+  @impl GenServer
+  def init(opts) do
+    room_id = Keyword.fetch!(opts, :id)
+
+    :ok =
+      Logger.info(
+        "#{__MODULE__} :: Started for room=#{room_id}, pid=#{inspect(self())}"
+      )
+
+    {:ok, %{id: room_id}, {:continue, :register}}
+  end
+
+  @impl GenServer
+  def handle_continue(:register, %{id: room_id} = state) do
+    {:ok, _} = Registry.register(@registry_module, room_id, state)
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_call(:play, _from, %{id: room_id} = state) do
+    played_at = DateTime.utc_now()
+
+    reply =
+      case Player.play(room_id, played_at: played_at) do
+        {:ok, player} -> {:ok, PlaybackPosition.sync(player)}
+        error -> error
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:pause, opts}, _from, %{id: room_id} = state) do
+    at = Keyword.fetch!(opts, :at)
+
+    reply =
+      case Player.pause(room_id, at: at) do
+        {:ok, player} -> {:ok, PlaybackPosition.sync(player)}
+        error -> error
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call(:sync_player, _from, %{id: room_id} = state) do
+    reply =
+      case Player.get(room_id) do
+        {:ok, player} -> {:ok, PlaybackPosition.sync(player)}
+        error -> error
+      end
+
+    {:reply, reply, state}
+  end
+end

--- a/lib/livedj/sessions/playback_position.ex
+++ b/lib/livedj/sessions/playback_position.ex
@@ -1,0 +1,32 @@
+defmodule Livedj.Sessions.PlaybackPosition do
+  @moduledoc """
+  Computes playback position from stored `current_time` and `played_at`.
+  """
+
+  alias Livedj.Sessions.Player
+
+  @spec sync(Player.t()) :: Player.t()
+  def sync(
+        %Player{state: :playing, played_at: %DateTime{} = played_at} = player
+      ) do
+    base = to_integer(player.current_time)
+    elapsed = DateTime.diff(DateTime.utc_now(), played_at, :second)
+
+    %{player | current_time: max(0, base + elapsed)}
+  end
+
+  def sync(%Player{} = player),
+    do: %{player | current_time: to_integer(player.current_time)}
+
+  @spec to_integer(non_neg_integer() | binary() | any()) :: non_neg_integer()
+  defp to_integer(value) when is_integer(value) and value >= 0, do: value
+
+  defp to_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _offset} when int >= 0 -> int
+      _other_error -> 0
+    end
+  end
+
+  defp to_integer(_else), do: 0
+end

--- a/lib/livedj/sessions/playback_position.ex
+++ b/lib/livedj/sessions/playback_position.ex
@@ -18,6 +18,23 @@ defmodule Livedj.Sessions.PlaybackPosition do
   def sync(%Player{} = player),
     do: %{player | current_time: to_integer(player.current_time)}
 
+  @doc """
+  Returns true when a playing track has reached its stored duration.
+  """
+  @spec track_ended?(Player.t(), non_neg_integer()) :: boolean()
+  def track_ended?(player, epsilon \\ 1) do
+    player = sync(player)
+
+    case player do
+      %Player{state: :playing, duration: duration, current_time: position}
+      when is_integer(duration) and duration > 0 ->
+        position >= duration - epsilon
+
+      _else ->
+        false
+    end
+  end
+
   @spec to_integer(non_neg_integer() | binary() | any()) :: non_neg_integer()
   defp to_integer(value) when is_integer(value) and value >= 0, do: value
 

--- a/lib/livedj/sessions/player.ex
+++ b/lib/livedj/sessions/player.ex
@@ -17,6 +17,7 @@ defmodule Livedj.Sessions.Player do
             media_thumbnail_url: nil,
             current_time: 0,
             played_at: nil,
+            duration: nil,
             title: nil,
             channel: nil
 
@@ -25,7 +26,9 @@ defmodule Livedj.Sessions.Player do
   @type t :: %__MODULE__{}
   @type player_opts :: [
           {:seek_to, non_neg_integer()},
-          {:played_at, DateTime.t()}
+          {:played_at, DateTime.t()},
+          {:duration, non_neg_integer()},
+          {:autoplay, boolean()}
         ]
 
   @idle_state :idle
@@ -98,15 +101,15 @@ defmodule Livedj.Sessions.Player do
           {:ok, t()} | {:error, :player_load_media_error | :player_not_found}
   def load_media(room_id, media, opts) do
     params =
-      maybe_merge_opts(
-        %{
-          media_id: media.external_id,
-          media_thumbnail_url: media.thumbnail_url,
-          title: media.title,
-          channel: media.channel
-        },
-        opts
-      )
+      %{
+        media_id: media.external_id,
+        media_thumbnail_url: media.thumbnail_url,
+        title: media.title,
+        channel: media.channel
+      }
+      |> maybe_merge_opts(opts)
+      |> maybe_merge_duration(opts)
+      |> apply_load_playback_state(opts)
 
     case set(room_id, params) do
       {:ok, _changes} ->
@@ -123,7 +126,7 @@ defmodule Livedj.Sessions.Player do
   @spec clear_media(Ecto.UUID.t()) ::
           {:ok, t()} | {:error, :player_clear_media_error | :player_not_found}
   def clear_media(room_id) do
-    case set(room_id, %{media_id: nil}) do
+    case set(room_id, %{media_id: nil, duration: ""}) do
       {:ok, _changes} ->
         get(room_id)
 
@@ -249,7 +252,46 @@ defmodule Livedj.Sessions.Player do
     end
   end
 
+  defp parse_hset_value(:duration, ""), do: nil
+  defp parse_hset_value(:duration, nil), do: nil
+
+  defp parse_hset_value(:duration, value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _offset} when int > 0 -> int
+      _other_error -> nil
+    end
+  end
+
+  defp parse_hset_value(:duration, value) when is_integer(value) and value > 0,
+    do: value
+
   defp parse_hset_value(_key, value), do: value
+
+  @spec maybe_merge_duration(map(), player_opts()) :: map()
+  defp maybe_merge_duration(params, opts) do
+    case Keyword.get(opts, :duration) do
+      duration when is_integer(duration) and duration > 0 ->
+        Map.put(params, :duration, duration)
+
+      _else ->
+        Map.put(params, :duration, "")
+    end
+  end
+
+  # Clears timing from the previous track so the playback clock does not
+  # treat the new load as already finished.
+  @spec apply_load_playback_state(map(), player_opts()) :: map()
+  defp apply_load_playback_state(params, opts) do
+    if Keyword.get(opts, :autoplay, false) do
+      params
+      |> Map.put(:state, @playing_state)
+      |> Map.put(:played_at, DateTime.utc_now() |> DateTime.to_iso8601())
+    else
+      params
+      |> Map.put(:state, @paused_state)
+      |> Map.put(:played_at, "")
+    end
+  end
 
   @spec maybe_merge_opts(map(), player_opts()) :: map()
   defp maybe_merge_opts(params, opts) do

--- a/lib/livedj/sessions/player.ex
+++ b/lib/livedj/sessions/player.ex
@@ -16,6 +16,7 @@ defmodule Livedj.Sessions.Player do
             media_id: nil,
             media_thumbnail_url: nil,
             current_time: 0,
+            played_at: nil,
             title: nil,
             channel: nil
 
@@ -23,7 +24,8 @@ defmodule Livedj.Sessions.Player do
 
   @type t :: %__MODULE__{}
   @type player_opts :: [
-          {:seek_to, non_neg_integer()}
+          {:seek_to, non_neg_integer()},
+          {:played_at, DateTime.t()}
         ]
 
   @idle_state :idle
@@ -152,8 +154,14 @@ defmodule Livedj.Sessions.Player do
   @spec play(Ecto.UUID.t(), keyword()) ::
           {:ok, t()}
           | {:error, :player_update_play_state_error | :player_not_found}
-  def play(room_id, _opts) do
-    case set(room_id, %{state: @playing_state}) do
+  def play(room_id, opts \\ []) do
+    played_at =
+      case Keyword.get(opts, :played_at) do
+        %DateTime{} = dt -> DateTime.to_iso8601(dt)
+        _else -> DateTime.utc_now() |> DateTime.to_iso8601()
+      end
+
+    case set(room_id, %{state: @playing_state, played_at: played_at}) do
       {:ok, _changes} ->
         get(room_id)
 
@@ -169,7 +177,11 @@ defmodule Livedj.Sessions.Player do
           {:ok, t()}
           | {:error, :player_update_pause_state_error | :player_not_found}
   def pause(room_id, at: current_time) do
-    case set(room_id, %{current_time: current_time, state: @paused_state}) do
+    case set(room_id, %{
+           current_time: current_time,
+           state: @paused_state,
+           played_at: ""
+         }) do
       {:ok, _changes} ->
         get(room_id)
 
@@ -217,6 +229,26 @@ defmodule Livedj.Sessions.Player do
 
   @spec parse_hset_value(atom(), any()) :: any()
   defp parse_hset_value(:state, value), do: String.to_atom(value)
+
+  defp parse_hset_value(:current_time, value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _offset} when int >= 0 -> int
+      _other_error -> 0
+    end
+  end
+
+  defp parse_hset_value(:current_time, value) when is_integer(value), do: value
+
+  defp parse_hset_value(:played_at, ""), do: nil
+  defp parse_hset_value(:played_at, nil), do: nil
+
+  defp parse_hset_value(:played_at, value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> datetime
+      _other_error -> nil
+    end
+  end
+
   defp parse_hset_value(_key, value), do: value
 
   @spec maybe_merge_opts(map(), player_opts()) :: map()

--- a/lib/livedj/sessions/player_server.ex
+++ b/lib/livedj/sessions/player_server.ex
@@ -1,6 +1,10 @@
 defmodule Livedj.Sessions.PlayerServer do
   @moduledoc """
-  The Playlist Server implementation
+  Per-room GenServer that coordinates player members and a single controller.
+
+  The controller is the only member allowed to report YouTube lifecycle events
+  (e.g. track ended). The first member to join becomes controller; when the
+  controller disconnects, another member is promoted.
   """
   use GenServer, restart: :transient
 
@@ -12,24 +16,22 @@ defmodule Livedj.Sessions.PlayerServer do
   @play_msg :play
   @pause_msg :pause
   @state_change_msg :state_change
+  @report_track_ended_msg :report_track_ended
 
   @joined_cb :joined
-  # @playing_cb :playing
-  # @paused_cb :paused
-  # @ended_cb :ended
   @on_start_cb :on_start
 
   @type state :: %{
           :id => binary(),
+          :controller => pid() | nil,
           :members => map()
         }
-
-  @type element :: any()
 
   @type join_response :: {:ok, :joined}
   @type state_change_response :: :ok
   @type play_response :: :ok
   @type pause_response :: :ok
+  @type report_track_ended_response :: {:ok, :handled} | {:ok, :ignored}
 
   # ----------------------------------------------------------------------------
   # Client interface
@@ -77,6 +79,17 @@ defmodule Livedj.Sessions.PlayerServer do
   end
 
   @doc """
+  Reports that the current track ended in the YouTube player.
+
+  Only the room controller's caller process may trigger the callback; other
+  members receive `{:ok, :ignored}`.
+  """
+  @spec report_track_ended(pid(), keyword()) :: report_track_ended_response()
+  def report_track_ended(pid, cbs) do
+    GenServer.call(pid, {@report_track_ended_msg, cbs})
+  end
+
+  @doc """
   Given a keyword of args returns a new map that represents the #{__MODULE__}
   state.
   """
@@ -84,6 +97,7 @@ defmodule Livedj.Sessions.PlayerServer do
   def initial_state(opts) do
     %{
       id: Keyword.fetch!(opts, :id),
+      controller: nil,
       members: Map.new()
     }
   end
@@ -111,9 +125,28 @@ defmodule Livedj.Sessions.PlayerServer do
       "#{__MODULE__} :: User with pid: #{inspect(pid)} just joined the server."
     )
 
-    state = add_member(state, ref, pid)
+    state =
+      state
+      |> add_member(ref, pid)
+      |> maybe_elect_controller(pid)
 
     {:reply, {:ok, :joined}, state, {:continue, {@joined_cb, pid, cbs}}}
+  end
+
+  def handle_call({@report_track_ended_msg, cbs}, {caller, _ref}, state) do
+    if controller?(state, caller) do
+      {{on_track_ended, args}, []} = Keyword.pop!(cbs, :on_track_ended)
+
+      :ok = apply(on_track_ended, args)
+
+      {:reply, {:ok, :handled}, state}
+    else
+      Logger.debug(
+        "#{__MODULE__} :: Ignoring track ended from non-controller pid=#{inspect(caller)}, controller=#{inspect(state.controller)}"
+      )
+
+      {:reply, {:ok, :ignored}, state}
+    end
   end
 
   @impl GenServer
@@ -166,12 +199,23 @@ defmodule Livedj.Sessions.PlayerServer do
   def handle_info({:DOWN, ref, :process, pid, reason}, state) do
     state = remove_member(state, ref)
 
+    state =
+      if state.controller == pid do
+        promote_controller(state)
+      else
+        state
+      end
+
     Logger.debug(
       "Member with pid=#{inspect(pid)} left with reason=#{inspect(reason)}"
     )
 
     {:noreply, state}
   end
+
+  @spec controller?(state(), pid()) :: boolean()
+  defp controller?(%{controller: controller}, caller),
+    do: controller != nil and controller == caller
 
   @spec add_member(state(), reference(), pid()) :: state()
   defp add_member(%{members: members} = state, ref, pid),
@@ -180,4 +224,22 @@ defmodule Livedj.Sessions.PlayerServer do
   @spec remove_member(state(), reference()) :: state()
   defp remove_member(%{members: members} = state, ref),
     do: %{state | members: Map.delete(members, ref)}
+
+  @spec maybe_elect_controller(state(), pid()) :: state()
+  defp maybe_elect_controller(%{controller: nil} = state, pid),
+    do: %{state | controller: pid}
+
+  defp maybe_elect_controller(state, _pid), do: state
+
+  @spec promote_controller(state()) :: state()
+  defp promote_controller(state) do
+    case Map.values(state.members) do
+      [] ->
+        %{state | controller: nil}
+
+      members ->
+        controller = members |> Enum.sort() |> List.first()
+        %{state | controller: controller}
+    end
+  end
 end

--- a/lib/livedj/sessions/player_supervisor.ex
+++ b/lib/livedj/sessions/player_supervisor.ex
@@ -8,17 +8,24 @@ defmodule Livedj.Sessions.PlayerSupervisor do
 
   alias Livedj.Sessions
   alias Livedj.Sessions.Exceptions.PlayerServerError
-  alias Livedj.Sessions.Player
-  alias Livedj.Sessions.PlayerServer
+  alias Livedj.Sessions.{PlaybackClock, Player, PlayerServer}
 
   @server_module PlayerServer
+  @clock_module PlaybackClock
   @registry_module Registry.Player
+  @clock_registry_module Registry.PlaybackClock
 
   @spec server_module() :: module()
   def server_module, do: @server_module
 
   @spec registry_module() :: module()
   def registry_module, do: @registry_module
+
+  @spec clock_module() :: module()
+  def clock_module, do: @clock_module
+
+  @spec clock_registry_module() :: module()
+  def clock_registry_module, do: @clock_registry_module
 
   @doc """
   Given a keyword of args, initialises the dynamic Playlist Supervisor.
@@ -67,7 +74,51 @@ defmodule Livedj.Sessions.PlayerSupervisor do
 
     args = Keyword.put(args, :on_start, on_start)
 
-    DynamicSupervisor.start_child(supervisor, {server_module(), args})
+    with {:ok, player_pid} <-
+           DynamicSupervisor.start_child(supervisor, {server_module(), args}),
+         {:ok, _clock_pid} <- start_playback_clock(supervisor, id) do
+      {:ok, player_pid}
+    end
+  end
+
+  @doc """
+  Starts a `#{PlaybackClock}` for a room when one is not already running.
+  """
+  @spec start_playback_clock(module(), binary()) ::
+          {:ok, pid()} | {:error, any()}
+  def start_playback_clock(supervisor \\ __MODULE__, room_id) do
+    case get_playback_clock(room_id) do
+      {pid, _state} when is_pid(pid) ->
+        {:ok, pid}
+
+      nil ->
+        DynamicSupervisor.start_child(
+          supervisor,
+          {@clock_module, [id: room_id]}
+        )
+    end
+  end
+
+  @doc """
+  Returns `nil` or `{pid, state}` for the room's playback clock.
+  """
+  @spec get_playback_clock(binary()) :: {pid(), map()} | nil
+  def get_playback_clock(room_id) do
+    case Registry.lookup(@clock_registry_module, room_id) do
+      [] -> nil
+      [{pid, state}] -> {pid, state}
+    end
+  end
+
+  @doc """
+  Returns the playback clock pid for a room, raising if missing.
+  """
+  @spec get_playback_clock_pid!(binary()) :: pid()
+  def get_playback_clock_pid!(room_id) do
+    case get_playback_clock(room_id) do
+      nil -> raise PlayerServerError, reason: :playback_clock_not_found
+      {pid, _state} -> pid
+    end
   end
 
   @doc """

--- a/lib/livedj/sessions/supervisor.ex
+++ b/lib/livedj/sessions/supervisor.ex
@@ -4,7 +4,7 @@ defmodule Livedj.Sessions.Supervisor do
   """
   use Supervisor
 
-  alias Livedj.Sessions.{PlayerSupervisor, PlaylistSupervisor}
+  alias Livedj.Sessions.{PlaybackClock, PlayerSupervisor, PlaylistSupervisor}
 
   @spec start_link(keyword()) :: {:ok, pid()}
   def start_link(init_arg) do
@@ -15,6 +15,7 @@ defmodule Livedj.Sessions.Supervisor do
   def init(_init_arg) do
     children = [
       {Registry, keys: :unique, name: PlayerSupervisor.registry_module()},
+      {Registry, keys: :unique, name: PlaybackClock.registry_module()},
       {Registry, keys: :unique, name: PlaylistSupervisor.registry_module()},
       {PlayerSupervisor, []},
       {PlaylistSupervisor, []}

--- a/lib/livedj/sessions/video_duration.ex
+++ b/lib/livedj/sessions/video_duration.ex
@@ -1,0 +1,73 @@
+defmodule Livedj.Sessions.VideoDuration do
+  @moduledoc """
+  Fetches and parses YouTube video duration via Tubex.
+  """
+
+  require Logger
+
+  @youtube_duration ~r/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/
+
+  @spec fetch_seconds(binary()) ::
+          {:ok, non_neg_integer()} | {:error, :no_duration}
+  def fetch_seconds(external_id) do
+    external_id
+    |> Tubex.Video.detail()
+    |> duration_from_detail_response(external_id)
+  end
+
+  # Tubex.Video.detail/1 returns the decoded API body map on success, not {:ok, map()}.
+  @spec duration_from_detail_response(term(), binary()) ::
+          {:ok, non_neg_integer()} | {:error, :no_duration}
+  defp duration_from_detail_response(
+         %{"items" => [%{"contentDetails" => %{"duration" => iso}} | _]},
+         _external_id
+       ) do
+    case parse_iso8601_duration(iso) do
+      {:ok, seconds} -> {:ok, seconds}
+      :error -> {:error, :no_duration}
+    end
+  end
+
+  defp duration_from_detail_response({:error, _reason}, _external_id),
+    do: {:error, :no_duration}
+
+  defp duration_from_detail_response(response, external_id) do
+    Logger.debug(
+      "#{__MODULE__} :: No duration for external_id=#{external_id} response=#{inspect(response)}"
+    )
+
+    {:error, :no_duration}
+  end
+
+  @spec parse_iso8601_duration(binary()) :: {:ok, non_neg_integer()} | :error
+  def parse_iso8601_duration(iso) when is_binary(iso) do
+    case Regex.run(@youtube_duration, iso) do
+      [_, hours, minutes, seconds] ->
+        total =
+          parse_component(hours) * 3600 +
+            parse_component(minutes) * 60 +
+            parse_component(seconds)
+
+        if total > 0 do
+          {:ok, total}
+        else
+          :error
+        end
+
+      _else ->
+        :error
+    end
+  end
+
+  def parse_iso8601_duration(_else), do: :error
+
+  @spec parse_component(binary()) :: non_neg_integer()
+  defp parse_component(""), do: 0
+
+  defp parse_component(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _offset} when int >= 0 -> int
+      _other_error -> 0
+    end
+  end
+end

--- a/lib/livedj_web/live/sessions/room_live/show.ex
+++ b/lib/livedj_web/live/sessions/room_live/show.ex
@@ -94,7 +94,7 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
   end
 
   def handle_event("on_player_ended", _params, socket) do
-    # The player state changed to ended.
+    :ok = Sessions.report_track_ended(socket.assigns.room.id)
     {:noreply, socket}
   end
 

--- a/test/livedj/sessions/playback_clock_test.exs
+++ b/test/livedj/sessions/playback_clock_test.exs
@@ -3,6 +3,7 @@ defmodule Livedj.Sessions.PlaybackClockTest do
 
   alias Livedj.Sessions.{PlaybackClock, PlaybackPosition, Player, Room}
 
+  import Livedj.MediaFixtures
   import Livedj.SessionsFixtures
 
   describe "play/1 and pause/2" do
@@ -45,6 +46,35 @@ defmodule Livedj.Sessions.PlaybackClockTest do
 
       {:ok, %Player{played_at: nil, state: :paused, current_time: 5}} =
         Player.get(room_id)
+    end
+
+    test "load_media persists duration in redis", %{room_id: room_id} do
+      media = video_fixture()
+
+      assert {:ok, %Player{duration: 120}} =
+               Player.load_media(room_id, media, seek_to: 0, duration: 120)
+    end
+
+    test "load_media with autoplay clears stale played_at so track is not instantly ended",
+         %{
+           room_id: room_id
+         } do
+      _media = video_fixture()
+      other = video_fixture()
+
+      {:ok, _} = Player.play(room_id)
+      Process.sleep(1100)
+
+      assert {:ok, %Player{state: :playing, played_at: played_at}} =
+               Player.load_media(room_id, other,
+                 seek_to: 0,
+                 duration: 300,
+                 autoplay: true
+               )
+
+      assert %DateTime{} = played_at
+      {:ok, player} = Player.get(room_id)
+      refute PlaybackPosition.track_ended?(player)
     end
   end
 end

--- a/test/livedj/sessions/playback_clock_test.exs
+++ b/test/livedj/sessions/playback_clock_test.exs
@@ -1,0 +1,50 @@
+defmodule Livedj.Sessions.PlaybackClockTest do
+  use Livedj.DataCase
+
+  alias Livedj.Sessions.{PlaybackClock, PlaybackPosition, Player, Room}
+
+  import Livedj.SessionsFixtures
+
+  describe "play/1 and pause/2" do
+    setup do
+      %Room{id: room_id} = room_fixture()
+      {:ok, _} = Player.maybe_initialise_player(room_id)
+      clock_pid = start_supervised!({PlaybackClock, [id: room_id]})
+
+      %{room_id: room_id, clock_pid: clock_pid}
+    end
+
+    test "play sets played_at and sync advances position", %{
+      clock_pid: clock_pid
+    } do
+      {:ok, %Player{state: :playing, played_at: played_at}} =
+        PlaybackClock.play(clock_pid)
+
+      assert %DateTime{} = played_at
+
+      Process.sleep(1100)
+
+      {:ok, synced} = PlaybackClock.sync_player(clock_pid)
+      assert synced.current_time >= 1
+
+      {:ok, %Player{state: :paused, played_at: nil, current_time: at}} =
+        PlaybackClock.pause(clock_pid, at: synced.current_time)
+
+      assert at == synced.current_time
+
+      assert PlaybackPosition.sync(%{synced | state: :paused, played_at: nil}).current_time ==
+               at
+    end
+
+    test "pause clears played_at in redis", %{
+      room_id: room_id,
+      clock_pid: clock_pid
+    } do
+      {:ok, _} = PlaybackClock.play(clock_pid)
+      {:ok, _} = PlaybackClock.pause(clock_pid, at: 5)
+
+      {:ok, %Player{played_at: nil, state: :paused, current_time: 5}} =
+        Player.get(room_id)
+    end
+  end
+end

--- a/test/livedj/sessions/playback_position_test.exs
+++ b/test/livedj/sessions/playback_position_test.exs
@@ -30,4 +30,31 @@ defmodule Livedj.Sessions.PlaybackPositionTest do
       assert %Player{current_time: 15} = PlaybackPosition.sync(player)
     end
   end
+
+  describe "track_ended?/2" do
+    test "is true when playing position reached duration" do
+      played_at = DateTime.utc_now() |> DateTime.add(-100, :second)
+
+      player = %Player{
+        state: :playing,
+        current_time: 0,
+        played_at: played_at,
+        duration: 90
+      }
+
+      assert PlaybackPosition.track_ended?(player)
+    end
+
+    test "is false without duration" do
+      player = %Player{state: :playing, current_time: 999, duration: nil}
+
+      refute PlaybackPosition.track_ended?(player)
+    end
+
+    test "is false when paused" do
+      player = %Player{state: :paused, current_time: 100, duration: 10}
+
+      refute PlaybackPosition.track_ended?(player)
+    end
+  end
 end

--- a/test/livedj/sessions/playback_position_test.exs
+++ b/test/livedj/sessions/playback_position_test.exs
@@ -1,0 +1,33 @@
+defmodule Livedj.Sessions.PlaybackPositionTest do
+  use ExUnit.Case
+
+  alias Livedj.Sessions.{PlaybackPosition, Player}
+
+  describe "sync/1" do
+    test "returns stored current_time when paused" do
+      player = %Player{state: :paused, current_time: 42, played_at: nil}
+
+      assert %Player{current_time: 42} = PlaybackPosition.sync(player)
+    end
+
+    test "advances current_time while playing from played_at" do
+      played_at = DateTime.utc_now() |> DateTime.add(-10, :second)
+
+      player = %Player{
+        state: :playing,
+        current_time: 30,
+        played_at: played_at
+      }
+
+      synced = PlaybackPosition.sync(player)
+      assert synced.current_time >= 39
+      assert synced.current_time <= 41
+    end
+
+    test "coerces string current_time from redis" do
+      player = %Player{state: :paused, current_time: "15", played_at: nil}
+
+      assert %Player{current_time: 15} = PlaybackPosition.sync(player)
+    end
+  end
+end

--- a/test/livedj/sessions/player_server_test.exs
+++ b/test/livedj/sessions/player_server_test.exs
@@ -1,0 +1,140 @@
+defmodule Livedj.Sessions.PlayerServerTest do
+  use Livedj.DataCase
+
+  alias Livedj.Sessions.{PlayerServer, Room}
+
+  import Livedj.SessionsFixtures
+
+  @subject PlayerServer
+
+  describe "controller and report_track_ended/2" do
+    setup do
+      %Room{id: room_id} = room_fixture()
+      on_start = fn _state -> :ok end
+      pid = start_supervised!({@subject, [on_start: on_start, id: room_id]})
+
+      %{pid: pid, room_id: room_id}
+    end
+
+    test "first joiner becomes controller and may report track ended", %{
+      pid: pid
+    } do
+      parent = self()
+
+      controller =
+        spawn(fn ->
+          {:ok, :joined} =
+            @subject.join(pid, on_joined: {fn -> {:ok, %{}} end, []})
+
+          send(parent, {:ready, self()})
+
+          receive do
+            {:report, reply_to} ->
+              result =
+                @subject.report_track_ended(pid,
+                  on_track_ended:
+                    {fn ->
+                       send(reply_to, :track_ended_cb)
+                       :ok
+                     end, []}
+                )
+
+              send(reply_to, {:report_result, result})
+          end
+        end)
+
+      assert_receive {:ready, ^controller}
+
+      send(controller, {:report, self()})
+      assert_receive :track_ended_cb
+      assert_receive {:report_result, {:ok, :handled}}
+    end
+
+    test "non-controller joiner reports are ignored", %{pid: pid} do
+      parent = self()
+
+      controller =
+        spawn(fn ->
+          {:ok, :joined} =
+            @subject.join(pid, on_joined: {fn -> {:ok, %{}} end, []})
+
+          send(parent, :controller_joined)
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive :controller_joined
+
+      follower =
+        spawn(fn ->
+          {:ok, :joined} =
+            @subject.join(pid, on_joined: {fn -> {:ok, %{}} end, []})
+
+          send(parent, :follower_joined)
+
+          result =
+            @subject.report_track_ended(pid,
+              on_track_ended: {fn -> send(parent, :should_not_run) end, []}
+            )
+
+          send(parent, {:report_result, result})
+        end)
+
+      assert_receive :follower_joined
+      assert_receive {:report_result, {:ok, :ignored}}
+      refute_receive :should_not_run, 50
+      Process.exit(follower, :kill)
+      Process.exit(controller, :kill)
+    end
+
+    test "promotes a new controller when the current controller leaves", %{
+      pid: pid
+    } do
+      parent = self()
+
+      _controller =
+        spawn(fn ->
+          {:ok, :joined} =
+            @subject.join(pid, on_joined: {fn -> {:ok, %{}} end, []})
+
+          send(parent, {:controller, self()})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:controller, controller_pid}
+
+      _follower =
+        spawn(fn ->
+          {:ok, :joined} =
+            @subject.join(pid, on_joined: {fn -> {:ok, %{}} end, []})
+
+          send(parent, {:follower, self()})
+
+          receive do
+            {:report, reply_to} ->
+              result =
+                @subject.report_track_ended(pid,
+                  on_track_ended:
+                    {fn ->
+                       send(reply_to, :promoted_cb)
+                       :ok
+                     end, []}
+                )
+
+              send(reply_to, {:report_result, result})
+          end
+        end)
+
+      assert_receive {:follower, follower_pid}
+
+      Process.exit(controller_pid, :kill)
+      ref = Process.monitor(controller_pid)
+      assert_receive {:DOWN, ^ref, :process, ^controller_pid, _}
+
+      send(follower_pid, {:report, self()})
+      assert_receive :promoted_cb
+      assert_receive {:report_result, {:ok, :handled}}
+
+      Process.exit(follower_pid, :kill)
+    end
+  end
+end

--- a/test/livedj/sessions/video_duration_test.exs
+++ b/test/livedj/sessions/video_duration_test.exs
@@ -1,0 +1,27 @@
+defmodule Livedj.Sessions.VideoDurationTest do
+  use ExUnit.Case
+
+  alias Livedj.Sessions.VideoDuration
+
+  describe "parse_iso8601_duration/1" do
+    test "parses hours, minutes, and seconds" do
+      assert {:ok, 3661} = VideoDuration.parse_iso8601_duration("PT1H1M1S")
+    end
+
+    test "parses minutes and seconds" do
+      assert {:ok, 93} = VideoDuration.parse_iso8601_duration("PT1M33S")
+    end
+
+    test "parses seconds only" do
+      assert {:ok, 30} = VideoDuration.parse_iso8601_duration("PT30S")
+    end
+
+    test "rejects empty duration" do
+      assert :error = VideoDuration.parse_iso8601_duration("PT")
+    end
+
+    test "rejects invalid format" do
+      assert :error = VideoDuration.parse_iso8601_duration("not-a-duration")
+    end
+  end
+end


### PR DESCRIPTION
# Server-authoritative playback clock and playlist auto-advance

## Description

> Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Multi-tab rooms used to treat every browser's YouTube iframe as a source of truth. Lifecycle events (`ENDED`, etc.) could fire from each client, and playback position lived only in Redis on explicit play/pause—not while a track was actually playing.

This PR makes the **server** the authority for playback timing and playlist advancement, in three layers:

**This PR provides:**

- A **room controller** in `PlayerServer`: only one joined LiveView may report track-ended; the first joiner is controller, with promotion on disconnect.
- **`PlaybackClock`** per room: records `played_at` on play, clears it on pause, and computes position via `PlaybackPosition` for joins and API reads.
- **Phase 2b auto-advance**: fetches track **duration** from Tubex (`VideoDuration`), ticks while `:playing`, and calls `next_track/1` when position reaches duration; last track pauses at end instead of looping.
- **`load_media` reset**: clears stale `played_at` on load; `autoplay: true` for next/previous/play-track so auto-advance does not skip after ~1s.
- **Dedup**: `on_player_ended` from the iframe only advances when duration is unknown (fallback when Tubex has no duration).
- **Bug fixes**: Tubex `detail/1` returns a bare map (not `{:ok, map()}`); `get_player` syncs via `PlaybackPosition` directly to avoid `PlaybackClock` calling itself during `next_track`.
- Unit tests for `PlayerServer` controller, `PlaybackPosition`, `PlaybackClock`, and `VideoDuration`.

Closes #issue-number

## Type of change

- [x] Bug fix *(non-breaking change which fixes an issue)*
- [x] New feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to not work as expected)*
- [ ] This change requires a documentation update
- [ ] Documentation update

## How Has This Been Tested?

> Provide instructions so we can reproduce the cases. Please also list any relevant details for your test configuration.

**Instructions:**

1. Start the app (`make server` or equivalent) with Redis and `YOUTUBE_API_KEY` configured.
2. Open a room with **2+ videos** in the playlist; start playback from one tab.
3. Let the first track play to the end (do not click next).
4. Open the **same room in a second tab** while the first track is playing; confirm the second tab loads near the current position (not `0:00`).
5. With two tabs open, let a track end; confirm the playlist advances **once** (not twice).
6. Let the **last** track play to the end; confirm it does not skip after ~1s and does not loop `next_track` (should stop at end).
7. Run unit tests: `MIX_ENV=test mix test test/livedj/sessions/`
8. Run Dialyzer: `mix check.dialyzer`

**Expected result:**

- Auto-advance to the next track when duration is known, without crashing the `PlaybackClock` process.
- Reconnecting clients receive a synced `current_time` from the server clock.
- Only the controller tab's `on_player_ended` advances when duration is missing; with duration, the server tick handles advance.

## Checklist

- [x] **I have performed a self-review of my own code**
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] **My changes generate no new warnings**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] **New and existing unit tests pass locally with my changes**

---

## Commits

- `5732dde` — Gate track-ended reports through a room controller
- `c52982e` — Add server playback clock for play/pause and join sync (phase 2a)
- `f599043` — Add server tick and duration-based auto-advance (phase 2b)
