### PR TITLE
Polish search modal UX and reflect muted state on the volume button

### DIFF
--- a/lib/livedj/sessions.ex
+++ b/lib/livedj/sessions.ex
@@ -352,6 +352,8 @@ defmodule Livedj.Sessions do
 
   @spec on_track_ended(binary()) :: :ok
   defp on_track_ended(room_id) do
+    :ok = Channels.broadcast_player_track_ended!(room_id)
+
     case Player.get(room_id) do
       {:ok, %Player{duration: duration}}
       when is_integer(duration) and duration > 0 ->

--- a/lib/livedj/sessions/channels.ex
+++ b/lib/livedj/sessions/channels.ex
@@ -21,6 +21,7 @@ defmodule Livedj.Sessions.Channels do
   @player_play :player_play
   @player_pause :player_pause
   @player_load_media :player_load_media
+  @track_ended :track_ended
 
   # ----------------------------------------------------------------------------
   # Playlist event aliases
@@ -120,6 +121,12 @@ defmodule Livedj.Sessions.Channels do
   @spec player_load_media_event() :: :player_load_media
   def player_load_media_event, do: @player_load_media
 
+  @doc """
+  Returns the message name for track ended events
+  """
+  @spec track_ended_event() :: :track_ended
+  def track_ended_event, do: @track_ended
+
   # ----------------------------------------------------------------------------
   # Playlist events
   #
@@ -211,6 +218,13 @@ defmodule Livedj.Sessions.Channels do
   def broadcast_player_pause!(room_id, %Livedj.Sessions.Player{} = player),
     do:
       broadcast!(player_topic(room_id), {player_pause_event(), room_id, player})
+
+  @doc """
+  Broadcasts a #{@track_ended} message to the player topic.
+  """
+  @spec broadcast_player_track_ended!(binary()) :: :ok
+  def broadcast_player_track_ended!(room_id),
+    do: broadcast!(player_topic(room_id), {track_ended_event(), room_id})
 
   # ----------------------------------------------------------------------------
   # Playlist brodcasting

--- a/lib/livedj_web/components/list_component.ex
+++ b/lib/livedj_web/components/list_component.ex
@@ -101,23 +101,40 @@ defmodule LivedjWeb.ListComponent do
               ">
                 <%= item.title %>
               </div>
-              <button
-                type="button"
-                class="
-                  cursor-default
-                  transition-all duration-300
-                  w-6 h-6 rounded-md mr-1 flex-none hover:bg-gray-300 hover:dark:bg-gray-700
-                  text-zinc-900 dark:text-zinc-100 hover:text-red-500 hover:dark:text-red-500
-                  focus:ring-2 focus:ring-zinc-900 focus:dark:ring-zinc-50
-                "
-                phx-click="remove_track"
-                phx-value-track_id={item.external_id}
-                tabindex="0"
-                href="#"
-                data-confirm={gettext("Remove '%{title}'?", title: item.title)}
-              >
-                <.icon name="hero-x-mark" class="" />
-              </button>
+              <%= if current_media?(@current_media, item.external_id) do %>
+                <button
+                  type="button"
+                  disabled
+                  aria-disabled="true"
+                  title={gettext("The currently playing track can't be removed")}
+                  class="
+                    cursor-not-allowed opacity-40
+                    w-6 h-6 rounded-md mr-1 flex-none
+                    text-zinc-900 dark:text-zinc-100
+                  "
+                  tabindex="-1"
+                >
+                  <.icon name="hero-x-mark" class="" />
+                </button>
+              <% else %>
+                <button
+                  type="button"
+                  class="
+                    cursor-pointer
+                    transition-all duration-300
+                    w-6 h-6 rounded-md mr-1 flex-none hover:bg-gray-300 hover:dark:bg-gray-700
+                    text-zinc-900 dark:text-zinc-100 hover:text-red-500 hover:dark:text-red-500
+                    focus:ring-2 focus:ring-zinc-900 focus:dark:ring-zinc-50
+                  "
+                  phx-click="remove_track"
+                  phx-value-track_id={item.external_id}
+                  tabindex="0"
+                  href="#"
+                  data-confirm={gettext("Remove '%{title}'?", title: item.title)}
+                >
+                  <.icon name="hero-x-mark" class="" />
+                </button>
+              <% end %>
             </div>
           </div>
         </div>

--- a/lib/livedj_web/live/components/add_video_component.ex
+++ b/lib/livedj_web/live/components/add_video_component.ex
@@ -9,8 +9,6 @@ defmodule LivedjWeb.Components.AddVideoComponent do
       <.live_component
         id={"video_search_bar_#{@room.id}"}
         module={LivedjWeb.Components.SearchBarComponent}
-        form={@search_form}
-        search_result={@search_result}
         room={@room}
       >
         <:button>
@@ -30,7 +28,7 @@ defmodule LivedjWeb.Components.AddVideoComponent do
             text-zinc-900 dark:text-zinc-100
             active:text-green-500 dark:active:text-green-500
           ">
-            <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+            <.icon name="hero-plus" class="w-4 h-4" />
           </.button>
         </:button>
       </.live_component>
@@ -42,11 +40,7 @@ defmodule LivedjWeb.Components.AddVideoComponent do
   def mount(socket) do
     {:ok,
      socket
-     |> assign(
-       player: to_form(%{}),
-       search_form: to_form(%{}),
-       search_result: []
-     )}
+     |> assign(player: to_form(%{}))}
   end
 
   @impl true

--- a/lib/livedj_web/live/components/add_video_component.ex
+++ b/lib/livedj_web/live/components/add_video_component.ex
@@ -14,7 +14,7 @@ defmodule LivedjWeb.Components.AddVideoComponent do
         <:button>
           <.button class="
             rounded-md
-            cursor-default w-6 h-6 !p-0 flex flex-wrap justify-center content-center
+            cursor-pointer w-6 h-6 !p-0 flex flex-wrap justify-center content-center
             align-middle bg-zinc-300 dark:bg-zinc-700
             transition-all duration-300
             shadow-[2.0px_2.0px_1px_0.5px_rgba(24,24,27,0.5)]

--- a/lib/livedj_web/live/components/player_controls/volume_control_component.ex
+++ b/lib/livedj_web/live/components/player_controls/volume_control_component.ex
@@ -12,13 +12,12 @@ defmodule LivedjWeb.Components.PlayerControls.VolumeControlComponent do
       fill-zinc-700 hover:fill-zinc-900 focus:fill-zinc-700 active:fill-zinc-700
       dark:fill-zinc-300 dark:hover:fill-zinc-50 dark:focus:fill-zinc-300 dark:active:fill-zinc-300
     ">
-      <.link
+      <.button
         tabindex="0"
         phx-key="m"
         phx-window-keydown="on_volume_click"
-        class="
-          fill-zinc-900 dark:fill-zinc-50
-          focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:dark:ring-zinc-50"
+        class={volume_button_class(@muted?)}
+        aria-pressed={@muted?}
         href="#"
         phx-click="on_volume_click"
         phx-target={@myself}
@@ -27,9 +26,9 @@ defmodule LivedjWeb.Components.PlayerControls.VolumeControlComponent do
           LivedjWeb.Endpoint,
           get_volume_icon(@muted?, @level),
           "icons/volume",
-          class: "h-5 w-5"
+          class: "h-6 w-6 p-1"
         ) %>
-      </.link>
+      </.button>
       <div class="ml-2 self-center hidden md:block">
         <.form
           :let={f}
@@ -92,6 +91,44 @@ defmodule LivedjWeb.Components.PlayerControls.VolumeControlComponent do
        muted?: false
      )
      |> push_event("change_volume", %{volume_level: volume})}
+  end
+
+  defp volume_button_class(muted?) do
+    [
+      "focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:dark:ring-zinc-50",
+      "rounded-md",
+      "cursor-pointer w-6 h-6 !p-0 flex flex-wrap justify-center content-center",
+      "align-middle transition-all duration-300 group",
+      "hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(24,24,27,0.9)]",
+      "active:shadow-[0.5px_0.5px_1px_0.5px_rgba(24,24,27,0.2)]",
+      "dark:hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.6)]",
+      "dark:active:shadow-[0.5px_0.5px_1px_0.5px_rgba(250,250,255,0.2)]",
+      "hover:bg-zinc-300 dark:hover:bg-zinc-700",
+      "active:bg-zinc-200 dark:active:bg-zinc-800",
+      "active:text-green-500 dark:active:text-green-500",
+      muted_state_class(muted?)
+    ]
+    |> Enum.join(" ")
+  end
+
+  defp muted_state_class(true) do
+    """
+    fill-red-500
+    bg-zinc-200 dark:bg-zinc-800
+    text-green-500 dark:text-green-500
+    shadow-[0.5px_0.5px_1px_0.5px_rgba(24,24,27,0.2)]
+    dark:shadow-[0.5px_0.5px_1px_0.5px_rgba(250,250,255,0.2)]
+    """
+  end
+
+  defp muted_state_class(_muted?) do
+    """
+    fill-zinc-900 dark:fill-zinc-50
+    bg-zinc-300 dark:bg-zinc-700
+    text-zinc-900 dark:text-zinc-100
+    shadow-[2.0px_2.0px_1px_0.5px_rgba(24,24,27,0.5)]
+    dark:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.4)]
+    """
   end
 
   defp get_volume_icon(true, _volume_level) do

--- a/lib/livedj_web/live/components/search_bar_component.ex
+++ b/lib/livedj_web/live/components/search_bar_component.ex
@@ -49,6 +49,23 @@ defmodule LivedjWeb.Components.SearchBarComponent do
     query_present?(form[:query].value)
   end
 
+  def search_kbd_class do
+    """
+    stroke-zinc-300 w-10 m-0 h-6 sm:h-7 rounded-md
+    flex justify-center items-center border-[1px]
+    border-zinc-500 dark:border-zinc-600 opacity-50
+    hover:opacity-80 active:opacity-100
+    bg-zinc-500 dark:bg-zinc-700 text-zinc-300 dark:text-zinc-200
+    text-xs md:text-sm font-medium cursor-pointer
+    shadow-[2.0px_2.0px_1px_0.5px_rgba(24,24,27,0.5)]
+    hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(24,24,27,0.9)]
+    active:shadow-[0.5px_0.5px_1px_0.5px_rgba(24,24,27,0.2)]
+    dark:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.4)]
+    dark:hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.6)]
+    dark:active:shadow-[0.5px_0.5px_1px_0.5px_rgba(250,250,255,0.2)]
+    """
+  end
+
   defp query_present?(query) do
     query |> to_string() |> String.trim() != ""
   end
@@ -72,7 +89,7 @@ defmodule LivedjWeb.Components.SearchBarComponent do
   def hide_modal(js \\ %JS{}) do
     js
     |> JS.hide(
-      to: "#searchbar-searchbox_container",
+      to: "#searchbox_container",
       transition:
         {"transition ease-in duration-300", "opacity-100 scale-100",
          "opacity-0 scale-95"}

--- a/lib/livedj_web/live/components/search_bar_component.ex
+++ b/lib/livedj_web/live/components/search_bar_component.ex
@@ -9,7 +9,9 @@ defmodule LivedjWeb.Components.SearchBarComponent do
   def update(assigns, socket) do
     {:ok,
      socket
-     |> assign(assigns)}
+     |> assign(assigns)
+     |> assign_new(:form, &empty_search_form/0)
+     |> assign_new(:search_result, fn -> [] end)}
   end
 
   @impl true
@@ -17,26 +19,38 @@ defmodule LivedjWeb.Components.SearchBarComponent do
     add_media(socket, media_id)
   end
 
-  def handle_event("change", %{"search" => %{"query" => ""}}, socket) do
-    {:noreply, socket}
+  def handle_event("change", %{"search" => %{"query" => query}}, socket) do
+    {:noreply, assign(socket, form: search_form(query))}
   end
 
-  def handle_event("change", %{"search" => %{"query" => _search_query}}, socket) do
+  def handle_event("change", _params, socket) do
     {:noreply, socket}
   end
 
   def handle_event("submit", %{"search" => %{"query" => search_query}}, socket) do
-    case validate_url(search_query) do
-      {:ok, media_id} ->
-        add_media(socket, media_id)
+    if query_present?(search_query) do
+      case validate_url(search_query) do
+        {:ok, media_id} ->
+          add_media(socket, media_id)
 
-      {:error, :invalid_url} ->
-        search_media(socket, search_query)
+        {:error, :invalid_url} ->
+          search_media(socket, search_query)
+      end
+    else
+      {:noreply, socket}
     end
   end
 
   def handle_event("submit", _params, socket) do
     {:noreply, socket}
+  end
+
+  def search_submit_enabled?(form) do
+    query_present?(form[:query].value)
+  end
+
+  defp query_present?(query) do
+    query |> to_string() |> String.trim() != ""
   end
 
   def open_modal(js \\ %JS{}) do
@@ -70,6 +84,10 @@ defmodule LivedjWeb.Components.SearchBarComponent do
     )
   end
 
+  defp empty_search_form, do: search_form("")
+
+  defp search_form(query), do: to_form(%{"query" => query}, as: :search)
+
   defp validate_url(url) do
     case URI.parse(url) do
       %URI{query: query} when not is_nil(query) ->
@@ -85,8 +103,8 @@ defmodule LivedjWeb.Components.SearchBarComponent do
       {:ok, {:added, media}} ->
         {:noreply,
          socket
-         |> assign(form: to_form(%{}))
-         |> assign(search_form: to_form(%{}))
+         |> assign(form: empty_search_form())
+         |> assign(search_result: [])
          |> put_flash(
            :info,
            gettext("%{title} queued to the playlist", title: media.title)
@@ -95,7 +113,7 @@ defmodule LivedjWeb.Components.SearchBarComponent do
       {:error, {type, msg}} when type in [:warn, :error] and is_binary(msg) ->
         {:noreply,
          socket
-         |> assign(form: to_form(%{}))
+         |> assign(form: empty_search_form())
          |> put_flash(type, msg)}
     end
   end
@@ -103,7 +121,10 @@ defmodule LivedjWeb.Components.SearchBarComponent do
   def search_media(socket, query) do
     case Sessions.search_by_query(query) do
       {:ok, result} ->
-        {:noreply, assign(socket, search_result: result)}
+        {:noreply,
+         socket
+         |> assign(search_result: result)
+         |> assign(form: search_form(query))}
 
       {:error, :service_unavailable} ->
         {:noreply,

--- a/lib/livedj_web/live/components/search_bar_component.html.heex
+++ b/lib/livedj_web/live/components/search_bar_component.html.heex
@@ -10,9 +10,11 @@
     "
     role="dialog"
     aria-modal="true"
-    phx-window-keyup={hide_modal()}
+    aria-label={gettext("Search videos")}
+    phx-window-keydown={hide_modal()}
     phx-key="escape"
   >
+    <p class="sr-only"><%= gettext("Press Escape to close") %></p>
     <div class="
       fixed inset-0
       backdrop-blur-lg opacity-100
@@ -72,7 +74,7 @@
                 type="search"
                 class="
                   w-full !m-0
-                  flex-auto rounded-md appearance-none bg-transparent pl-10 pr-10
+                  flex-auto rounded-md appearance-none bg-transparent pl-10 pr-28
                   !bg-zinc-400 !dark:bg-zinc-600
                   !text-zinc-700 !dark:text-zinc-300
                   outline-none focus:outline-none
@@ -105,39 +107,34 @@
                 enterkeyhint="search"
                 spellcheck="false"
                 tabindex="0"
+                phx-keydown={hide_modal()}
+                phx-key="escape"
                 phx-keyup="change"
                 phx-target={@myself}
               />
 
-              <button
-                type="submit"
-                disabled={!search_submit_enabled?(@form)}
-                aria-disabled={!search_submit_enabled?(@form)}
-                aria-label={gettext("Search")}
-                class="
-                  absolute right-3 top-[5px] stroke-zinc-300
-                  w-10 m-0 h-6 sm:h-7 rounded-md
-                  flex justify-center items-center
-                  border-[1px]
-                  border-zinc-500 dark:border-zinc-600
-                  opacity-50 hover:opacity-80 active:opacity-100
-                  disabled:opacity-30 disabled:hover:opacity-30 disabled:active:opacity-30
-                  bg-zinc-500 dark:bg-zinc-700
-                  text-zinc-300 dark:text-zinc-200
-                  text-xs md:text-sm font-medium
-                  cursor-pointer disabled:cursor-not-allowed
-                  shadow-[2.0px_2.0px_1px_0.5px_rgba(24,24,27,0.5)]
-                  hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(24,24,27,0.9)]
-                  active:shadow-[0.5px_0.5px_1px_0.5px_rgba(24,24,27,0.2)]
-                  disabled:shadow-none disabled:hover:shadow-none disabled:active:shadow-none
-                  dark:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.4)]
-                  dark:hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.6)]
-                  dark:active:shadow-[0.5px_0.5px_1px_0.5px_rgba(250,250,255,0.2)]
-                  dark:disabled:shadow-none dark:disabled:hover:shadow-none dark:disabled:active:shadow-none
-                "
-              >
-                (↵)
-              </button>
+              <div class="absolute right-3 top-[4px] flex items-center gap-2">
+                <button
+                  type="button"
+                  phx-click={hide_modal()}
+                  aria-label={gettext("Close search")}
+                  class={search_kbd_class()}
+                >
+                  esc
+                </button>
+                <button
+                  type="submit"
+                  disabled={!search_submit_enabled?(@form)}
+                  aria-disabled={!search_submit_enabled?(@form)}
+                  aria-label={gettext("Search")}
+                  class={
+                    search_kbd_class() <>
+                      " disabled:opacity-30 disabled:hover:opacity-30 disabled:active:opacity-30 disabled:cursor-not-allowed disabled:shadow-none disabled:hover:shadow-none disabled:active:shadow-none dark:disabled:shadow-none dark:disabled:hover:shadow-none dark:disabled:active:shadow-none"
+                  }
+                >
+                  (↵)
+                </button>
+              </div>
             </div>
 
             <ul

--- a/lib/livedj_web/live/components/search_bar_component.html.heex
+++ b/lib/livedj_web/live/components/search_bar_component.html.heex
@@ -68,7 +68,7 @@
               <.input
                 container_class="w-full"
                 id="search-input"
-                field={f[:value]}
+                field={f[:query]}
                 type="search"
                 class="
                   w-full !m-0
@@ -81,8 +81,8 @@
                   focus:ring-0 focus:shadow-none
                   focus:tracking-widest
                   transition-all duration-500
-                  placeholder:text-zinc-600 focus:placeholder:opacity-50
-                  dark:placeholder:text-zinc-300 focus:dark:placeholder:opacity-50
+                  placeholder:text-zinc-900 focus:placeholder:opacity-70
+                  dark:placeholder:text-zinc-100 focus:dark:placeholder:opacity-70
                   focus:w-full focus:flex-none
                   text-xs md:text-sm
                   [&::-webkit-search-cancel-button]:hidden
@@ -98,7 +98,6 @@
                 placeholder={
                   gettext("Insert a youtube url or search for a video")
                 }
-                name="search[query]"
                 aria-autocomplete="both"
                 aria-controls="searchbox__results_list"
                 autocomplete="off"
@@ -106,22 +105,39 @@
                 enterkeyhint="search"
                 spellcheck="false"
                 tabindex="0"
+                phx-keyup="change"
+                phx-target={@myself}
               />
 
-              <div class="
-                absolute right-3 top-[5px] stroke-zinc-300
-                w-10 m-0 h-6 sm:h-7 rounded-md
-                flex justify-center items-center
-                border-[1px]
-                border-zinc-500 dark:border-zinc-600
-                opacity-50
-                bg-zinc-500 dark:bg-zinc-700
-                text-zinc-300 dark:text-zinc-200
-                text-xs md:text-sm font-medium
-                cursor-default
-              ">
-                ESC
-              </div>
+              <button
+                type="submit"
+                disabled={!search_submit_enabled?(@form)}
+                aria-disabled={!search_submit_enabled?(@form)}
+                aria-label={gettext("Search")}
+                class="
+                  absolute right-3 top-[5px] stroke-zinc-300
+                  w-10 m-0 h-6 sm:h-7 rounded-md
+                  flex justify-center items-center
+                  border-[1px]
+                  border-zinc-500 dark:border-zinc-600
+                  opacity-50 hover:opacity-80 active:opacity-100
+                  disabled:opacity-30 disabled:hover:opacity-30 disabled:active:opacity-30
+                  bg-zinc-500 dark:bg-zinc-700
+                  text-zinc-300 dark:text-zinc-200
+                  text-xs md:text-sm font-medium
+                  cursor-pointer disabled:cursor-not-allowed
+                  shadow-[2.0px_2.0px_1px_0.5px_rgba(24,24,27,0.5)]
+                  hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(24,24,27,0.9)]
+                  active:shadow-[0.5px_0.5px_1px_0.5px_rgba(24,24,27,0.2)]
+                  disabled:shadow-none disabled:hover:shadow-none disabled:active:shadow-none
+                  dark:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.4)]
+                  dark:hover:shadow-[1.5px_1.5px_1px_0.5px_rgba(250,250,255,0.6)]
+                  dark:active:shadow-[0.5px_0.5px_1px_0.5px_rgba(250,250,255,0.2)]
+                  dark:disabled:shadow-none dark:disabled:hover:shadow-none dark:disabled:active:shadow-none
+                "
+              >
+                (↵)
+              </button>
             </div>
 
             <ul

--- a/lib/livedj_web/live/components/search_bar_component.html.heex
+++ b/lib/livedj_web/live/components/search_bar_component.html.heex
@@ -213,7 +213,7 @@
                       transition duration-300 opacity-0 group-hover:opacity-100
                       w-12 h-12 rounded-lg
                       bg-transparent
-                      cursor-default
+                      cursor-pointer
                       text-zinc-700 dark:text-zinc-300
                       hover:text-green-500 dark:hover:text-green-500 hover:scale-110
                       focus:text-green-500 dark:focus:text-green-500 focus:scale-110 focus:opacity-100

--- a/lib/livedj_web/live/player_controls_live.ex
+++ b/lib/livedj_web/live/player_controls_live.ex
@@ -104,6 +104,8 @@ defmodule LivedjWeb.PlayerControlsLive do
     {:noreply, assign_player(socket, player)}
   end
 
+  def handle_info({:track_ended, _room_id}, socket), do: {:noreply, socket}
+
   @spec assign_player(Phoenix.LiveView.Socket.t(), Sessions.Player.t()) ::
           Phoenix.LiveView.Socket.t()
   defp assign_player(socket, player), do: assign(socket, :player, player)

--- a/lib/livedj_web/live/player_controls_live.html.heex
+++ b/lib/livedj_web/live/player_controls_live.html.heex
@@ -57,7 +57,7 @@
             <a
               href="#"
               phx-click="previous"
-              class="cursor-default h-8 w-8 flex justify-center items-center"
+              class="cursor-pointer h-8 w-8 flex justify-center items-center"
               tabindex="0"
             >
               <%= PhoenixInlineSvg.Helpers.svg_image(
@@ -75,7 +75,7 @@
               <a
                 href="#"
                 phx-click={on_pause_click_event()}
-                class="cursor-default rounded-full h-10 w-10 flex justify-center items-center hover:scale-105"
+                class="cursor-pointer rounded-full h-10 w-10 flex justify-center items-center hover:scale-105"
                 tabindex="0"
               >
                 <.icon
@@ -88,7 +88,7 @@
               <a
                 href="#"
                 phx-click={on_play_click_event()}
-                class="cursor-default rounded-full h-10 w-10 flex justify-center items-center hover:scale-105"
+                class="cursor-pointer rounded-full h-10 w-10 flex justify-center items-center hover:scale-105"
                 tabindex="0"
               >
                 <.icon
@@ -100,7 +100,7 @@
             <a
               href="#"
               phx-click="next"
-              class="cursor-default h-8 w-8 flex justify-center items-center"
+              class="cursor-pointer h-8 w-8 flex justify-center items-center"
               tabindex="0"
             >
               <%= PhoenixInlineSvg.Helpers.svg_image(

--- a/lib/livedj_web/live/sessions/room_live/list.ex
+++ b/lib/livedj_web/live/sessions/room_live/list.ex
@@ -68,6 +68,20 @@ defmodule LivedjWeb.Sessions.RoomLive.List do
     end
   end
 
+  def handle_event(
+        "remove_track",
+        %{"track_id" => track_id},
+        %{assigns: %{current_media: current_media}} = socket
+      )
+      when current_media == track_id do
+    {:noreply,
+     socket
+     |> put_flash(
+       :warn,
+       dgettext("errors", "The currently playing track can't be removed")
+     )}
+  end
+
   def handle_event("remove_track", %{"track_id" => track_id}, socket) do
     :ok = Sessions.remove_media(socket.assigns.room.id, track_id)
 
@@ -201,6 +215,17 @@ defmodule LivedjWeb.Sessions.RoomLive.List do
       ) do
     {:noreply, assign_current_media(socket, media_id)}
   end
+
+  @impl true
+  def handle_info(
+        {:track_ended, room_id},
+        %{assigns: %{room: %Room{id: room_id}}} = socket
+      ) do
+    {:noreply, assign(socket, :current_media, nil)}
+  end
+
+  @impl true
+  def handle_info({:track_ended, _room_id}, socket), do: {:noreply, socket}
 
   @spec assign_current_media(Phoenix.LiveView.Socket.t(), binary() | nil) ::
           Phoenix.LiveView.Socket.t()

--- a/lib/livedj_web/live/sessions/room_live/list.ex
+++ b/lib/livedj_web/live/sessions/room_live/list.ex
@@ -19,8 +19,6 @@ defmodule LivedjWeb.Sessions.RoomLive.List do
         {:ok,
          assign(socket,
            drag_state: :unlocked,
-           search_form: to_form(%{}),
-           search_result: [],
            layout: false,
            room: room,
            media_list: [],

--- a/lib/livedj_web/live/sessions/room_live/show.ex
+++ b/lib/livedj_web/live/sessions/room_live/show.ex
@@ -193,6 +193,8 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
      |> push_event("load_video", player)}
   end
 
+  def handle_info({:track_ended, _room_id}, socket), do: {:noreply, socket}
+
   @spec assign_player(Phoenix.LiveView.Socket.t(), Sessions.Player.t()) ::
           Phoenix.LiveView.Socket.t()
   defp assign_player(socket, player), do: assign(socket, :player, player)


### PR DESCRIPTION
---
name: Pull Request
about: Let us know about your contribution
title: 'Improve search bar UX and reflect muted state on the volume control'
labels: ''
assignees: '@sgobotta'
---

## Description

Polishes the video search modal and the volume button so they're more
discoverable, easier to use with the keyboard, and visually accurate.

The search submit affordance — previously a static `(↵)` hint — is now a real
submit button that mirrors the form state, and an adjacent `esc` chip both
documents and dispatches the modal-close shortcut. Escape dismissal was also
re-wired so it works from the focused input. Finally, the volume button now
visibly stays in its "pressed" state whenever the player is muted.

**This PR provides:**

- A clickable submit button in the search modal that triggers the form's
  `phx-submit` handler, replacing the static `(↵)` hint.
- A disabled state on the submit button while the search field is empty or
  whitespace-only, with matching styles and `cursor-not-allowed`.
- Migration of `form` and `search_result` state into `SearchBarComponent`
  so parent re-renders no longer desync the input and submit-button state.
- A new `esc` kbd chip beside `(↵)` that closes the modal on click, plus an
  `aria-label`, an `sr-only` hint, and a `Close search` label for assistive
  tech.
- A fix for Escape no longer closing the modal: switched to
  `phx-window-keydown`, added `phx-keydown="escape"` on the input so the
  shortcut works while typing, and corrected the `hide_modal` target
  selector (`#searchbox_container`).
- Muted-state styling for the volume button: applies the same bg / text /
  shadow used by the `:active` pseudo-class whenever `@muted?` is true, and
  exposes `aria-pressed` so screen readers announce the toggle state.

Closes #issue-number

## Type of change

- [x] Bug fix *(Escape no longer closing the search modal; search bar
      form/results state desync on parent re-render)*
- [x] New feature *(clickable search submit + `esc` chip + muted state on the
      volume button)*

## How Has This Been Tested?

Manual UI testing in the development server.

**Instructions:**

1. Open a room and click the search icon to open the search modal.
2. Verify the submit button is disabled (faded, `not-allowed` cursor) while
   the input is empty or contains only whitespace.
3. Type a query and verify the submit button enables in real time.
4. Click the submit button (or press Enter) and confirm a search is
   triggered, the same as before. Repeat with a YouTube URL.
5. Press `Esc` while focused on the input and confirm the modal closes.
6. Click the `esc` chip with the mouse and confirm the modal closes.
7. With the modal open, use a screen reader to verify it announces the
   dialog name and close hint.
8. In the player controls, click the volume button to mute. Confirm the
   button shows the pressed / green styles and `aria-pressed="true"` while
   muted, and returns to the resting state when unmuted.

**Expected result:** the search bar reflects form state accurately, both
Enter and the `(↵)` chip submit, both `Esc` and the `esc` chip close the
modal, and the volume button visually communicates the muted state.

## Checklist

- [x] **I have performed a self-review of my own code**
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] **My changes generate no new warnings**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] **New and existing unit tests pass locally with my changes**
