### PR TITLE
Fix dark mode on home page, mobile header scroll, and center session logo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ check.lint: SHELL:=/bin/bash
 check.lint:
 	@source ${LOCAL_ENV_FILE} && mix check.format
 	@source ${LOCAL_ENV_FILE} && mix check.credo
+	@cd assets && npx eslint js
 
 #🧹 clean.uploads: @ Removes all files from the uploads dir
 clean.uploads: SHELL:=/bin/bash
@@ -111,6 +112,7 @@ lint: MIX_ENV=dev
 lint:
 	@mix format
 	@mix check.credo
+	@cd assets && npx eslint js --fix
 
 #💣 reset: @ Cleans dependencies then re-installs and compiles them for all envs
 reset: SHELL:=/bin/bash

--- a/assets/.eslintrc.json
+++ b/assets/.eslintrc.json
@@ -75,7 +75,7 @@
         "require-yield": 2,
         "use-isnan": 2,
         "valid-typeof": 2,
-        "sort-imports": 2,
+        "sort-imports": ["error", { "ignoreDeclarationSort": true }],
         "sort-keys": 2,
         "no-duplicate-imports": 2,
         "no-var": 2,

--- a/assets/js/animation/noise.js
+++ b/assets/js/animation/noise.js
@@ -1,0 +1,31 @@
+const W = 160
+const H = 90
+
+export function startNoise(canvas) {
+  const ctx = canvas.getContext('2d')
+  canvas.width = W
+  canvas.height = H
+  const imageData = ctx.createImageData(W, H)
+  const data = imageData.data
+
+  function drawFrame() {
+    for (let i = 0; i < data.length; i += 4) {
+      const v = (Math.random() * 255) | 0
+      data[i] = v
+      data[i + 1] = v
+      data[i + 2] = v
+      data[i + 3] = 255
+    }
+    ctx.putImageData(imageData, 0, 0)
+    canvas._noiseRaf = requestAnimationFrame(drawFrame)
+  }
+
+  drawFrame()
+}
+
+export function stopNoise(canvas) {
+  cancelAnimationFrame(canvas._noiseRaf)
+  canvas._noiseRaf = null
+  const ctx = canvas.getContext('2d')
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+}

--- a/assets/js/animation/noise.js
+++ b/assets/js/animation/noise.js
@@ -10,7 +10,7 @@ export function startNoise(canvas) {
 
   function drawFrame() {
     for (let i = 0; i < data.length; i += 4) {
-      const v = (Math.random() * 255) | 0
+      const v = 80 + ((Math.random() * 75) | 0)
       data[i] = v
       data[i + 1] = v
       data[i + 2] = v

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -3,7 +3,15 @@ import { secondsToTime } from '../lib/date-utils'
 
 function scrollToElement(elementId) {
   const element = document.getElementById(elementId)
-  if (element) element.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  if (!element) return
+
+  const scrollContainer = document.getElementById('lists')
+  if (scrollContainer) {
+    const itemTop = element.offsetTop - scrollContainer.offsetTop
+    scrollContainer.scrollTo({ top: itemTop, behavior: 'smooth' })
+  } else {
+    element.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }
 }
 
 const updateTimeDisplay = (timeTrackerElem, time) => {

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -1,6 +1,6 @@
-import { secondsToTime } from '../lib/date-utils'
-import { startNoise, stopNoise } from '../animation/noise'
 import initPlayer from './player'
+import { startNoise, stopNoise } from '../animation/noise'
+import { secondsToTime } from '../lib/date-utils'
 
 function scrollToElement(elementId) {
   const element = document.getElementById(elementId)

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -8,9 +8,9 @@ function scrollToElement(elementId) {
   const scrollContainer = document.getElementById('lists')
   if (scrollContainer) {
     const itemTop = element.offsetTop - scrollContainer.offsetTop
-    scrollContainer.scrollTo({ top: itemTop, behavior: 'smooth' })
+    scrollContainer.scrollTo({ behavior: 'smooth', top: itemTop })
   } else {
-    element.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    element.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
   }
 }
 

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -1,5 +1,6 @@
-import initPlayer from './player'
 import { secondsToTime } from '../lib/date-utils'
+import { startNoise, stopNoise } from '../animation/noise'
+import initPlayer from './player'
 
 function scrollToElement(elementId) {
   const element = document.getElementById(elementId)
@@ -79,8 +80,9 @@ export default {
         `spinner_container_id=${this.spinnerId}`
       )
 
-      document.getElementById(this.spinnerId).classList.remove("hidden")
-      document.getElementById(this.spinnerId).classList.add("animate-ping")
+      const canvas = document.getElementById(this.spinnerId)
+      canvas.classList.remove("hidden")
+      startNoise(canvas)
 
       const onPlayerReady = player => {
         console.debug('[Player :: Ready]', player)
@@ -173,9 +175,9 @@ export default {
 
       this.player.g.classList.remove('hidden')
 
-      const spinner = document.getElementById(this.spinnerId)
-      spinner.classList.add('hidden')
-      spinner.classList.remove('animate-pulse')
+      const canvas = document.getElementById(this.spinnerId)
+      stopNoise(canvas)
+      canvas.classList.add('hidden')
 
       const backdrop = document.getElementById(this.backdropId)
       backdrop.classList.add('opacity-0')
@@ -223,6 +225,10 @@ export default {
       await this.player.playVideo()
       await this.pushEventTo(this.el, callbackEvent)
 
+      const canvas = document.getElementById(this.spinnerId)
+      stopNoise(canvas)
+      canvas.classList.add('hidden')
+
       const backdrop = document.getElementById(this.backdropId)
       backdrop.classList.add('opacity-0')
       backdrop.classList.remove('opacity-50')
@@ -240,9 +246,9 @@ export default {
       await this.player.pauseVideo()
       await this.pushEventTo(this.el, callbackEvent)
 
-      const spinner = document.getElementById(this.spinnerId)
-      spinner.classList.add("animate-ping")
-      spinner.classList.remove("hidden")
+      const canvas = document.getElementById(this.spinnerId)
+      canvas.classList.remove("hidden")
+      startNoise(canvas)
 
       const backdrop = document.getElementById(this.backdropId)
       backdrop.classList.remove("opacity-0")

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -3,7 +3,7 @@ import { secondsToTime } from '../lib/date-utils'
 
 function scrollToElement(elementId) {
   const element = document.getElementById(elementId)
-  if (element) element.scrollIntoView()
+  if (element) element.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
 }
 
 const updateTimeDisplay = (timeTrackerElem, time) => {

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -8,7 +8,7 @@ function scrollToElement(elementId) {
 
   const scrollContainer = document.getElementById('lists')
   if (scrollContainer) {
-    const itemTop = element.offsetTop - scrollContainer.offsetTop
+    const itemTop = element.offsetTop - scrollContainer.offsetTop - 8
     scrollContainer.scrollTo({ behavior: 'smooth', top: itemTop })
   } else {
     element.scrollIntoView({ behavior: 'smooth', block: 'nearest' })

--- a/lib/livedj_web/components/core_components.ex
+++ b/lib/livedj_web/components/core_components.ex
@@ -73,7 +73,7 @@ defmodule LivedjWeb.CoreComponents do
               phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
               class="
                 shadow-zinc-700/10 dark:shadow-300/10 ring-zinc-700/10 dark:ring-zinc-300/10
-                relative hidden rounded-2xl bg-zinc-200 border-[1px] border-zinc-400 dark:bg-zinc-900 p-14 shadow-lg ring-1 transition
+                relative hidden rounded-2xl bg-zinc-200 border-[1px] border-zinc-400 dark:bg-zinc-900 p-5 shadow-lg ring-1 transition
               "
             >
               <div class="absolute top-6 right-5">

--- a/lib/livedj_web/components/layouts/app.html.heex
+++ b/lib/livedj_web/components/layouts/app.html.heex
@@ -13,7 +13,7 @@
         </.link>
       </div>
     </div>
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-4">
       <.toggle_theme_button theme={@theme} />
       <.user_avatar user={assigns[:current_user]} />
     </div>

--- a/lib/livedj_web/components/layouts/session.html.heex
+++ b/lib/livedj_web/components/layouts/session.html.heex
@@ -55,12 +55,14 @@
     </ul> --%>
   </header>
 
-  <main class="sm:py-10 lg:px-8">
+  <main class="flex-1 overflow-y-auto sm:py-10 lg:px-8 bg-zinc-200 dark:bg-zinc-800">
     <div class="mx-1 sm:mx-auto max-w-xl">
       <.flash_group flash={@flash} />
       <%= @inner_content %>
     </div>
   </main>
+
+  <div class="shrink-0 h-24" />
 
   <footer class="absolute bottom-0 w-full">
     <%= live_render(

--- a/lib/livedj_web/components/layouts/session.html.heex
+++ b/lib/livedj_web/components/layouts/session.html.heex
@@ -1,13 +1,13 @@
 <div class="flex flex-col h-screen">
   <header class="px-4 sm:px-6 lg:px-8 static top-0 w-full">
-    <div class="flex items-center border-b border-zinc-300 dark:border-zinc-700 py-3 text-sm justify-between">
-      <div class="h-5 w-5" />
-      <div class="flex items-center gap-4">
+    <div class="grid grid-cols-3 items-center border-b border-zinc-300 dark:border-zinc-700 py-3 text-sm">
+      <div />
+      <div class="flex justify-center">
         <a href="/" data-confirm={gettext("Exit session?")}>
           <.livedj_logo theme={@theme} />
         </a>
       </div>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center justify-end gap-4">
         <.toggle_theme_button theme={@theme} />
         <.user_avatar user={@current_user} />
       </div>

--- a/lib/livedj_web/controllers/page_html/home.html.heex
+++ b/lib/livedj_web/controllers/page_html/home.html.heex
@@ -40,9 +40,16 @@
 </div>
 <div class="px-4 py-10 sm:px-6 sm:py-28 lg:px-8 xl:px-28 xl:py-32">
   <div class="mx-auto max-w-xl lg:mx-0">
-    <%= PhoenixInlineSvg.Helpers.svg_image(@conn, "live-dj-iso-black",
-      class: "w-40 h-40"
-    ) %>
+    <span class="dark:hidden">
+      <%= PhoenixInlineSvg.Helpers.svg_image(@conn, "live-dj-iso-black",
+        class: "w-40 h-40"
+      ) %>
+    </span>
+    <span class="hidden dark:inline">
+      <%= PhoenixInlineSvg.Helpers.svg_image(@conn, "live-dj-iso-white",
+        class: "w-40 h-40"
+      ) %>
+    </span>
     <h1 class="text-brand mt-10 flex items-center text-sm font-semibold leading-6">
       LiveDj
       <small class="bg-brand/5 text-[0.8125rem] ml-3 rounded-full px-2 font-medium leading-6">
@@ -54,10 +61,10 @@
         </.link>
       </small>
     </h1>
-    <p class="text-[2rem] mt-4 font-semibold leading-10 tracking-tighter text-zinc-900">
+    <p class="text-[2rem] mt-4 font-semibold leading-10 tracking-tighter text-zinc-900 dark:text-zinc-100">
       <%= gettext("Shared youtube sessions") %>
     </p>
-    <p class="mt-4 text-base leading-7 text-zinc-600">
+    <p class="mt-4 text-base leading-7 text-zinc-600 dark:text-zinc-400">
       <%= gettext(
         "Join or create a room with your friends, add videos and watch to youtube content in real time."
       ) %>
@@ -67,33 +74,37 @@
         <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-3">
           <a
             href={~p"/sessions/rooms"}
-            class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 sm:py-6"
+            class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 dark:text-zinc-100 sm:py-6"
           >
-            <span class="absolute inset-0 rounded-2xl bg-zinc-50 transition group-hover:bg-zinc-100 sm:group-hover:scale-105">
+            <span class="absolute inset-0 rounded-2xl bg-zinc-50 dark:bg-zinc-800 transition group-hover:bg-zinc-100 dark:group-hover:bg-zinc-700 sm:group-hover:scale-105">
             </span>
             <span class="relative flex items-center gap-4 sm:flex-col">
               <%= PhoenixInlineSvg.Helpers.svg_image(
                 @conn,
                 "compact-discs",
                 "icons",
-                class: "w-6 h-6"
+                class: "w-6 h-6 fill-zinc-900 dark:fill-zinc-100"
               ) %>
               <%= gettext("Rooms") %>
             </span>
           </a>
           <a
             href="https://github.com/sgobotta/live_dj"
-            class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 sm:py-6"
+            class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 dark:text-zinc-100 sm:py-6"
           >
-            <span class="absolute inset-0 rounded-2xl bg-zinc-50 transition group-hover:bg-zinc-100 sm:group-hover:scale-105">
+            <span class="absolute inset-0 rounded-2xl bg-zinc-50 dark:bg-zinc-800 transition group-hover:bg-zinc-100 dark:group-hover:bg-zinc-700 sm:group-hover:scale-105">
             </span>
             <span class="relative flex items-center gap-4 sm:flex-col">
-              <svg viewBox="0 0 24 24" aria-hidden="true" class="h-6 w-6">
+              <svg
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                class="h-6 w-6 fill-zinc-900 dark:fill-zinc-100"
+              >
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
                   d="M12 0C5.37 0 0 5.506 0 12.303c0 5.445 3.435 10.043 8.205 11.674.6.107.825-.262.825-.585 0-.292-.015-1.261-.015-2.291C6 21.67 5.22 20.346 4.98 19.654c-.135-.354-.72-1.446-1.23-1.738-.42-.23-1.02-.8-.015-.815.945-.015 1.62.892 1.845 1.261 1.08 1.86 2.805 1.338 3.495 1.015.105-.8.42-1.338.765-1.645-2.67-.308-5.46-1.37-5.46-6.075 0-1.338.465-2.446 1.23-3.307-.12-.308-.54-1.569.12-3.26 0 0 1.005-.323 3.3 1.26.96-.276 1.98-.415 3-.415s2.04.139 3 .416c2.295-1.6 3.3-1.261 3.3-1.261.66 1.691.24 2.952.12 3.26.765.861 1.23 1.953 1.23 3.307 0 4.721-2.805 5.767-5.475 6.075.435.384.81 1.122.81 2.276 0 1.645-.015 2.968-.015 3.383 0 .323.225.707.825.585a12.047 12.047 0 0 0 5.919-4.489A12.536 12.536 0 0 0 24 12.304C24 5.505 18.63 0 12 0Z"
-                  fill="#18181B"
+                  fill="currentColor"
                 />
               </svg>
               <%= gettext("Source Code") %>

--- a/lib/livedj_web/live/components/player_controls/volume_control_component.ex
+++ b/lib/livedj_web/live/components/player_controls/volume_control_component.ex
@@ -8,7 +8,7 @@ defmodule LivedjWeb.Components.PlayerControls.VolumeControlComponent do
     ~H"""
     <div class="
       inline-flex
-      md:w-28 w-5
+      md:w-28 w-6
       fill-zinc-700 hover:fill-zinc-900 focus:fill-zinc-700 active:fill-zinc-700
       dark:fill-zinc-300 dark:hover:fill-zinc-50 dark:focus:fill-zinc-300 dark:active:fill-zinc-300
     ">

--- a/lib/livedj_web/live/sessions/room_live/list.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/list.html.heex
@@ -2,6 +2,7 @@
   id="lists"
   class="
     grid sm:grid-cols-1 overflow-y-scroll h-32 sm:h-52 md:h-44 p-0
+    bg-zinc-200 dark:bg-zinc-800 py-2 rounded-md
   "
 >
   <.live_component

--- a/lib/livedj_web/live/sessions/room_live/list.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/list.html.heex
@@ -1,8 +1,8 @@
 <div
   id="lists"
   class="
-    grid sm:grid-cols-1 overflow-y-scroll h-32 sm:h-52 md:h-44 p-0
-    bg-zinc-200 dark:bg-zinc-800 py-2 rounded-md
+    grid sm:grid-cols-1 overflow-y-scroll h-96 sm:h-52 md:h-44 p-0
+    bg-zinc-200 dark:bg-zinc-900 py-2 rounded-md
   "
 >
   <.live_component

--- a/lib/livedj_web/live/sessions/room_live/list.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/list.html.heex
@@ -1,6 +1,9 @@
-<div id="lists" class="
-    grid sm:grid-cols-1 overflow-y-scroll h-64 p-0
-  ">
+<div
+  id="lists"
+  class="
+    grid sm:grid-cols-1 overflow-y-scroll h-32 sm:h-52 md:h-44 p-0
+  "
+>
   <.live_component
     id={"playlist_#{@room.id}"}
     current_media={@current_media}

--- a/lib/livedj_web/live/sessions/room_live/show.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/show.html.heex
@@ -30,7 +30,7 @@
         />
       </div>
     </div>
-    <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 my-2 py-4 mx-2">
+    <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 py-2 my-2 mx-1">
       <%= live_render(
         @socket,
         LivedjWeb.Sessions.RoomLive.List,

--- a/lib/livedj_web/live/sessions/room_live/show.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/show.html.heex
@@ -18,16 +18,7 @@
         id={@backdrop_id}
         class="absolute w-full h-full grid bg-black rounded-lg"
       >
-        <div
-          id={@spinner_id}
-          class="
-            hidden
-            w-24 h-24
-            self-center justify-self-center
-            rounded-full
-            bg-blue-200
-          "
-        />
+        <canvas id={@spinner_id} class="hidden w-full h-full rounded-lg" />
       </div>
     </div>
     <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 py-2 my-2 mx-1">

--- a/lib/livedj_web/live/sessions/room_live/show.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/show.html.heex
@@ -30,7 +30,7 @@
         />
       </div>
     </div>
-    <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 my-4 py-4 mx-2">
+    <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 my-2 py-4 mx-2">
       <%= live_render(
         @socket,
         LivedjWeb.Sessions.RoomLive.List,

--- a/lib/livedj_web/live/sessions/room_live/show.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/show.html.heex
@@ -14,11 +14,11 @@
         sticky: true
       ) %>
 
-      <div
-        id={@backdrop_id}
-        class="absolute w-full h-full grid bg-black rounded-lg"
-      >
-        <canvas id={@spinner_id} class="hidden w-full h-full rounded-lg" />
+      <div id={@backdrop_id} class="absolute w-full h-full bg-black rounded-lg">
+        <canvas
+          id={@spinner_id}
+          class="hidden absolute inset-0 w-full h-full rounded-lg"
+        />
       </div>
     </div>
     <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 py-2 my-2 mx-1">


### PR DESCRIPTION
This PR provides:

  - Dark mode fixes for the home page: per-theme logo switching (live-dj-iso-black / live-dj-iso-white), text and card background variants, and GitHub icon color
  - Reduced create room modal padding from p-14 (56px) to p-5 (20px)
  - Fix for session header disappearing on mobile when entering a room — scrollToElement was calling scrollIntoView() which bypasses overflow: hidden on iOS Safari and scrolled
  the viewport instead of the #lists container; replaced with a direct scrollTo scoped to #lists
  - Centered the logo in the session layout header using a 3-column grid so it stays geometrically centered regardless of the action buttons width

  Closes #issue-number

  ---
  Type of change:

  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)

  ---
  How Has This Been Tested?

  Instructions:

  1. Toggle dark mode on the home page — verify the logo switches between black/white variants and all text/cards render correctly
  2. Open the create room modal — verify the reduced padding
  3. On a mobile device (or iOS Safari DevTools), join a room with a track already playing — verify the header remains visible after the player loads
  4. Enter a room session — verify the logo is horizontally centered in the header

  Expected result: Home page renders correctly in both light and dark mode; session header logo is centered; entering a room on mobile does not cause the header to scroll off
  screen.

  ---
  Checklist:

  - I have performed a self-review of my own code
  - My changes generate no new warnings
  - New and existing unit tests pass locally with my changes