### PR TITLE
Shareable room URL, persistent volume, and player stability fixes

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -47,11 +47,15 @@ if (
     document.querySelector("meta[name='csrf-token']")
     .getAttribute("content")
   const _theme = localStorage.getItem("theme")
+  const _volume_level = localStorage.getItem("_volume_level") ?? "100"
+  const _volume_muted = localStorage.getItem("_volume_muted") ?? "false"
   const liveSocket = new LiveSocket("/live", Socket, {
     hooks: Hooks,
     params: {
       _csrf_token: csrfToken,
-      _theme
+      _theme,
+      _volume_level,
+      _volume_muted
     }
   })
   

--- a/assets/js/clipboard/hook.js
+++ b/assets/js/clipboard/hook.js
@@ -1,0 +1,12 @@
+export default {
+  mounted() {
+    this.el.addEventListener("click", () => {
+      const text = this.el.dataset.copyText
+      navigator.clipboard.writeText(text).then(() => {
+        const original = this.el.innerText
+        this.el.innerText = "Copied!"
+        setTimeout(() => { this.el.innerText = original }, 2000)
+      })
+    })
+  }
+}

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -1,9 +1,11 @@
+import Clipboard from './clipboard/hook'
 import SearchBar from './search-bar/hook'
 import Sortable from './sortable/hook'
 import Theme from './theme/hook'
 import Youtube from './youtube/hook'
 
 export default {
+  Clipboard,
   SearchBar,
   Sortable,
   Theme,

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -89,6 +89,18 @@ export default {
         player.g.classList.add("rounded-lg")
 
         this.player = player
+
+        const persistedLevel = parseInt(
+          localStorage.getItem("_volume_level") ?? "100", 10
+        )
+        const persistedMuted = localStorage.getItem("_volume_muted") === "true"
+        player.setVolume(persistedLevel)
+        if (persistedMuted) {
+          player.mute()
+        } else {
+          player.unMute()
+        }
+
         this.pushEventTo(this.el, 'on_player_loaded')
       }
 
@@ -307,6 +319,8 @@ export default {
       console.debug('[Player :: change_volume', volumeLevel)
       this.player.unMute()
       this.player.setVolume(volumeLevel)
+      localStorage.setItem("_volume_level", volumeLevel)
+      localStorage.setItem("_volume_muted", "false")
 
       await this.handleCallbackEvent(callbackEvent)
     })
@@ -319,6 +333,7 @@ export default {
     this.handleEvent('mute', async ({callback_event: callbackEvent = null}) => {
       console.debug('[Player :: mute')
       this.player.mute()
+      localStorage.setItem("_volume_muted", "true")
 
       await this.handleCallbackEvent(callbackEvent)
     })
@@ -333,6 +348,7 @@ export default {
     }) => {
       console.debug('[Player :: unmute')
       this.player.unMute()
+      localStorage.setItem("_volume_muted", "false")
 
       await this.handleCallbackEvent(callbackEvent)
     })

--- a/assets/js/youtube/hook.js
+++ b/assets/js/youtube/hook.js
@@ -54,6 +54,8 @@ export default {
     }
   },
   mounted() {
+    this.pushEventTo(this.el, 'on_player_container_mount')
+
     /**
      * on_container_mounted
      *

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -82,7 +82,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        brand: "#FD4F00"
+        brand: "violet"
       },
       fontFamily: {
         'sans': ['Montserrat-Thin', 'Helvetica', 'Arial', 'sans-serif']

--- a/lib/livedj/sessions.ex
+++ b/lib/livedj/sessions.ex
@@ -638,6 +638,23 @@ defmodule Livedj.Sessions do
       reraise SessionRoomError, [reason: :room_not_found], __STACKTRACE__
   end
 
+  @doc "Returns a randomly generated funny room name."
+  def generate_room_name do
+    patterns = [
+      fn -> "#{Faker.Color.En.name()} #{Faker.Team.En.creature()}s" end,
+      fn ->
+        "The #{Faker.Team.En.creature()}s from #{Faker.StarWars.En.planet()}"
+      end,
+      fn -> "#{Faker.Pokemon.name()}'s #{Faker.Team.En.creature()}s" end,
+      fn -> "#{Faker.Color.En.name()} #{Faker.Pokemon.name()} Lounge" end,
+      fn ->
+        "#{Faker.StarWars.En.planet()} #{Faker.Team.En.creature()}s Club"
+      end
+    ]
+
+    Enum.random(patterns).()
+  end
+
   @doc """
   Creates a room.
 

--- a/lib/livedj/sessions/room.ex
+++ b/lib/livedj/sessions/room.ex
@@ -15,7 +15,14 @@ defmodule Livedj.Sessions.Room do
   @doc false
   def changeset(room, attrs) do
     room
-    |> cast(attrs, [:name, :slug])
-    |> validate_required([:name, :slug])
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> maybe_put_slug()
   end
+
+  defp maybe_put_slug(%Ecto.Changeset{data: %{slug: nil}} = changeset) do
+    put_change(changeset, :slug, Ecto.UUID.generate())
+  end
+
+  defp maybe_put_slug(changeset), do: changeset
 end

--- a/lib/livedj_web/components/core_components.ex
+++ b/lib/livedj_web/components/core_components.ex
@@ -560,7 +560,7 @@ defmodule LivedjWeb.CoreComponents do
       @class
     ]}>
       <div>
-        <h1 class="text-lg font-semibold leading-8 text-zinc-800 dark:text-zinc-100">
+        <h1 class="text-lg font-normal leading-8 text-zinc-800 dark:text-zinc-100">
           <%= render_slot(@inner_block) %>
         </h1>
         <p

--- a/lib/livedj_web/components/core_components.ex
+++ b/lib/livedj_web/components/core_components.ex
@@ -65,7 +65,7 @@ defmodule LivedjWeb.CoreComponents do
         aria-modal="true"
       >
         <div class="flex min-h-full items-center justify-center">
-          <div class="w-full max-w-3xl p-4 sm:p-6 lg:py-8">
+          <div class="w-full max-w-lg p-4 sm:p-6 lg:py-8">
             <.focus_wrap
               id={"#{@id}-container"}
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}

--- a/lib/livedj_web/components/core_components.ex
+++ b/lib/livedj_web/components/core_components.ex
@@ -792,7 +792,6 @@ defmodule LivedjWeb.CoreComponents do
          "opacity-100"}
     )
     |> show("##{id}-container")
-    |> JS.add_class("overflow-hidden", to: "body")
     |> JS.focus_first(to: "##{id}-content")
   end
 
@@ -806,7 +805,6 @@ defmodule LivedjWeb.CoreComponents do
     )
     |> hide("##{id}-container")
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
-    |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.pop_focus()
   end
 

--- a/lib/livedj_web/components/custom_components.ex
+++ b/lib/livedj_web/components/custom_components.ex
@@ -49,7 +49,7 @@ defmodule LivedjWeb.CustomComponents do
   Renders the livedj logo
   """
   attr :theme, :string, required: true
-  attr :class, :string, default: "w-28 h-18"
+  attr :class, :string, default: "w-24 h-10"
 
   def livedj_logo(assigns) do
     ~H"""
@@ -71,7 +71,7 @@ defmodule LivedjWeb.CustomComponents do
     <p class="
       bg-brand/5 dark:bg-brand/100
       text-brand dark:text-white
-      rounded-full px-2 font-medium leading-6
+      rounded-full px-2 font-medium leading-6 text-xs
     ">
       v<%= @version %>
     </p>

--- a/lib/livedj_web/components/custom_components.ex
+++ b/lib/livedj_web/components/custom_components.ex
@@ -184,7 +184,7 @@ defmodule LivedjWeb.CustomComponents do
       id={@id}
       class="
         grid grid-rows-1 grid-flow-col auto-cols-max
-        my-4 py-4 w-max gap-4 px-1
+        py-4 w-max gap-4 px-1
       "
     >
       <div

--- a/lib/livedj_web/components/layouts/app.html.heex
+++ b/lib/livedj_web/components/layouts/app.html.heex
@@ -1,20 +1,17 @@
 <header class="px-4 sm:px-6 lg:px-8">
-  <div class="flex items-center justify-between border-b border-zinc-300 dark:border-zinc-700 py-3 text-sm">
-    <div class="flex items-center gap-4">
+  <div class="
+    grid grid-cols-3 items-center
+    border-b border-zinc-300 dark:border-zinc-700 py-3 text-sm
+  ">
+    <div class="flex items-center justify-start">
+      <.toggle_theme_button theme={@theme} />
+    </div>
+    <div class="flex items-center justify-center gap-4">
       <a href="/">
         <.livedj_logo theme={@theme} />
       </a>
-      <div class="cursor-default">
-        <.link
-          target="_blank"
-          href={"https://github.com/sgobotta/live_dj/releases/tag/v#{Application.spec(:livedj, :vsn)}"}
-        >
-          <.version_pill version={Application.spec(:livedj, :vsn)} />
-        </.link>
-      </div>
     </div>
-    <div class="flex items-center gap-4">
-      <.toggle_theme_button theme={@theme} />
+    <div class="flex items-center justify-end">
       <.user_avatar user={assigns[:current_user]} />
     </div>
   </div>
@@ -23,5 +20,13 @@
   <div class="mx-auto max-w-2xl z-50">
     <.flash_group flash={@flash} />
     <%= @inner_content %>
+  </div>
+  <div class="cursor-default absolute bottom-4 left-4">
+    <.link
+      target="_blank"
+      href={"https://github.com/sgobotta/live_dj/releases/tag/v#{Application.spec(:livedj, :vsn)}"}
+    >
+      <.version_pill version={Application.spec(:livedj, :vsn)} />
+    </.link>
   </div>
 </main>

--- a/lib/livedj_web/components/layouts/session.html.heex
+++ b/lib/livedj_web/components/layouts/session.html.heex
@@ -1,3 +1,50 @@
+<.modal
+  :if={assigns[:live_action] == :welcome}
+  id="welcome-modal"
+  show
+  on_cancel={JS.patch(~p"/sessions/rooms/#{assigns[:room]}")}
+>
+  <.header>
+    <%= gettext("Room ready to share!") %>
+    <:subtitle>
+      <%= gettext("Share the link below with your friends so they can join") %>
+    </:subtitle>
+  </.header>
+
+  <div class="mt-6 flex flex-col gap-3">
+    <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100 text-center">
+      <%= assigns[:room] && assigns[:room].name %>
+    </p>
+    <div class="flex items-center gap-2 rounded-lg bg-zinc-100 dark:bg-zinc-800 px-4 py-3">
+      <span class="flex-1 truncate text-sm text-zinc-700 dark:text-zinc-300 font-mono select-all">
+        <%= assigns[:room_url] %>
+      </span>
+      <button
+        phx-hook="Clipboard"
+        id="copy-room-url"
+        data-copy-text={assigns[:room_url]}
+        class="
+          shrink-0 rounded-md px-3 py-1.5 text-xs font-semibold
+          bg-zinc-900 dark:bg-zinc-100
+          text-zinc-50 dark:text-zinc-900
+          hover:bg-zinc-700 dark:hover:bg-zinc-300
+          transition-colors duration-150
+        "
+      >
+        <%= gettext("Copy") %>
+      </button>
+    </div>
+  </div>
+
+  <div class="mt-6 flex justify-end">
+    <.link patch={~p"/sessions/rooms/#{assigns[:room]}"}>
+      <.button>
+        <%= gettext("Enter room") %>
+      </.button>
+    </.link>
+  </div>
+</.modal>
+
 <div class="flex flex-col h-screen">
   <header class="px-4 sm:px-6 lg:px-8 static top-0 w-full">
     <div class="grid grid-cols-3 items-center border-b border-zinc-300 dark:border-zinc-700 py-3 text-sm">
@@ -68,6 +115,28 @@
   <main class="flex-1 overflow-y-auto sm:py-10 lg:px-8 bg-zinc-200 dark:bg-zinc-800">
     <div class="mx-1 sm:mx-auto max-w-xl">
       <.flash_group flash={@flash} />
+      <div
+        id="video-player-hook"
+        phx-hook="Youtube"
+        phx-update="ignore"
+        class="mx-1 w-[98%] h-72 relative flex my-2"
+      >
+        <%= live_render(@socket, LivedjWeb.PlayerLiveView,
+          id: "player-lv-container",
+          session: %{"player_id" => @player_container_id},
+          container: {:div, class: "w-full"},
+          sticky: true
+        ) %>
+        <div
+          id="player-backdrop"
+          class="absolute w-full h-full bg-black rounded-lg"
+        >
+          <canvas
+            id="player-spinner"
+            class="hidden absolute inset-0 w-full h-full rounded-lg"
+          />
+        </div>
+      </div>
       <%= @inner_content %>
     </div>
   </main>

--- a/lib/livedj_web/components/layouts/session.html.heex
+++ b/lib/livedj_web/components/layouts/session.html.heex
@@ -5,7 +5,7 @@
         <.toggle_theme_button theme={@theme} />
       </div>
       <div class="flex justify-center">
-        <a href="/" data-confirm={gettext("Exit session?")}>
+        <a href="/sessions/rooms" data-confirm={gettext("Exit session?")}>
           <.livedj_logo theme={@theme} />
         </a>
       </div>

--- a/lib/livedj_web/components/layouts/session.html.heex
+++ b/lib/livedj_web/components/layouts/session.html.heex
@@ -1,14 +1,15 @@
 <div class="flex flex-col h-screen">
   <header class="px-4 sm:px-6 lg:px-8 static top-0 w-full">
     <div class="grid grid-cols-3 items-center border-b border-zinc-300 dark:border-zinc-700 py-3 text-sm">
-      <div />
+      <div class="flex items-center justify-start">
+        <.toggle_theme_button theme={@theme} />
+      </div>
       <div class="flex justify-center">
         <a href="/" data-confirm={gettext("Exit session?")}>
           <.livedj_logo theme={@theme} />
         </a>
       </div>
       <div class="flex items-center justify-end gap-4">
-        <.toggle_theme_button theme={@theme} />
         <.user_avatar user={@current_user} />
       </div>
     </div>

--- a/lib/livedj_web/components/layouts/session.html.heex
+++ b/lib/livedj_web/components/layouts/session.html.heex
@@ -10,6 +10,15 @@
         </a>
       </div>
       <div class="flex items-center justify-end gap-4">
+        <!-- <%= if assigns[:room] do %>
+          <button
+            phx-click="open_share_modal"
+            title={gettext("Share room")}
+            class="text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors duration-150"
+          >
+            <.icon name="hero-clipboard-document" class="h-5 w-5" />
+          </button>
+        <% end %> -->
         <.user_avatar user={@current_user} />
       </div>
     </div>

--- a/lib/livedj_web/components/list_component.ex
+++ b/lib/livedj_web/components/list_component.ex
@@ -6,8 +6,8 @@ defmodule LivedjWeb.ListComponent do
 
   def render(assigns) do
     ~H"""
-    <div class="bg-transparent py-1 rounded-lg pr-1">
-      <div class="space-y-5 mx-auto max-w-7xl space-y-4 select-none pl-1">
+    <div class="bg-transparent px-1 py-1 rounded-lg">
+      <div class="space-y-5 mx-auto max-w-7xl select-none">
         <div id={"#{@id}-items"} phx-hook="Sortable" data-list_id={@id}>
           <div
             :for={{item, index} <- Enum.with_index(@list)}
@@ -20,7 +20,7 @@ defmodule LivedjWeb.ListComponent do
                 else: "text-zinc-900 dark:text-zinc-100 bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-900 dark:hover:bg-zinc-800"
               }
               #{if @state == :locked, do: "border-dashed", else: ""}
-              my-2 rounded-xl border-zinc-300 dark:border-zinc-700 border-[0px]
+              my-1 rounded-xl border-zinc-300 dark:border-zinc-700 border-[0px]
               hover:cursor-grab
               drag-item:focus-within:ring-2 drag-item:focus-within:ring-offset-0
               drag-ghost:bg-zinc-200 drag-ghost:dark:bg-zinc-800 drag-ghost:border-0 drag-ghost:ring-0 drag-ghost:cursor-grabbing

--- a/lib/livedj_web/controllers/page_controller.ex
+++ b/lib/livedj_web/controllers/page_controller.ex
@@ -4,6 +4,6 @@ defmodule LivedjWeb.PageController do
   def home(conn, _params) do
     # The home page is often custom made,
     # so skip the default app layout.
-    render(conn, :home, layout: false)
+    render(conn, :home, layout: false, theme: "light")
   end
 end

--- a/lib/livedj_web/controllers/page_html/home.html.heex
+++ b/lib/livedj_web/controllers/page_html/home.html.heex
@@ -1,4 +1,7 @@
 <.flash_group flash={@flash} />
+<div class="absolute top-5 left-8 z-10">
+  <.toggle_theme_button theme={@theme} />
+</div>
 <div class="left-[40rem] fixed inset-y-0 right-0 z-0 hidden lg:block xl:left-[50rem]">
   <svg
     viewBox="0 0 1480 957"

--- a/lib/livedj_web/live/player_controls_live.ex
+++ b/lib/livedj_web/live/player_controls_live.ex
@@ -13,6 +13,13 @@ defmodule LivedjWeb.PlayerControlsLive do
         %Room{id: room_id} = room = Sessions.get_room!(params["id"])
         {:ok, :joined} = Sessions.join_player(room_id)
 
+        connect_params = get_connect_params(socket)
+
+        volume_level =
+          String.to_integer(connect_params["_volume_level"] || "100")
+
+        volume_muted = connect_params["_volume_muted"] == "true"
+
         {:ok,
          assign(socket,
            player_controls_id: "player-controls-#{Ecto.UUID.generate()}",
@@ -24,7 +31,9 @@ defmodule LivedjWeb.PlayerControlsLive do
            add_video_control_id: "add-video-control-#{room_id}",
            layout: false,
            player: nil,
-           room: room
+           room: room,
+           volume_level: volume_level,
+           volume_muted: volume_muted
          )}
 
       false ->

--- a/lib/livedj_web/live/player_controls_live.html.heex
+++ b/lib/livedj_web/live/player_controls_live.html.heex
@@ -132,8 +132,8 @@
           <.live_component
             id={@volume_control_id}
             module={LivedjWeb.Components.PlayerControls.VolumeControlComponent}
-            level={100}
-            muted?={false}
+            level={@volume_level}
+            muted?={@volume_muted}
           />
           <%!-- Fullscreen --%>
           <.live_component

--- a/lib/livedj_web/live/sessions/room_live/form_component.ex
+++ b/lib/livedj_web/live/sessions/room_live/form_component.ex
@@ -27,12 +27,7 @@ defmodule LivedjWeb.Sessions.RoomLive.FormComponent do
           field={@form[:name]}
           type="text"
           label={gettext("Name")}
-          class="focus:ring-2 focus:ring-zinc-900 focus:dark:ring-zinc-50"
-        />
-        <.input
-          field={@form[:slug]}
-          type="text"
-          label={gettext("Slug")}
+          placeholder={@placeholder_name}
           class="focus:ring-2 focus:ring-zinc-900 focus:dark:ring-zinc-50"
         />
         <:actions>
@@ -52,6 +47,7 @@ defmodule LivedjWeb.Sessions.RoomLive.FormComponent do
     {:ok,
      socket
      |> assign(assigns)
+     |> assign(:placeholder_name, Sessions.generate_room_name())
      |> assign_form(changeset)}
   end
 
@@ -66,6 +62,12 @@ defmodule LivedjWeb.Sessions.RoomLive.FormComponent do
   end
 
   def handle_event("save", %{"room" => room_params}, socket) do
+    room_params =
+      case String.trim(room_params["name"] || "") do
+        "" -> Map.put(room_params, "name", socket.assigns.placeholder_name)
+        _name -> room_params
+      end
+
     save_room(socket, socket.assigns.action, room_params)
   end
 
@@ -92,7 +94,7 @@ defmodule LivedjWeb.Sessions.RoomLive.FormComponent do
         {:noreply,
          socket
          |> put_flash(:info, gettext("Room created successfully"))
-         |> push_patch(to: socket.assigns.patch)}
+         |> push_navigate(to: ~p"/sessions/rooms/#{room}")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/livedj_web/live/sessions/room_live/form_component.ex
+++ b/lib/livedj_web/live/sessions/room_live/form_component.ex
@@ -94,7 +94,7 @@ defmodule LivedjWeb.Sessions.RoomLive.FormComponent do
         {:noreply,
          socket
          |> put_flash(:info, gettext("Room created successfully"))
-         |> push_navigate(to: ~p"/sessions/rooms/#{room}")}
+         |> push_navigate(to: ~p"/sessions/rooms/#{room}/welcome")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/livedj_web/live/sessions/room_live/index.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/index.html.heex
@@ -1,6 +1,6 @@
 <%= if connected?(@socket) do %>
   <.header class="text-zinc-900 dark:text-zinc-100">
-    <%= gettext("Playing now...") %>
+    <%= gettext("Public rooms") %>
   </.header>
 
   <div class="w-full overflow-x-scroll" id="salsa">

--- a/lib/livedj_web/live/sessions/room_live/list.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/list.html.heex
@@ -2,7 +2,7 @@
   id="lists"
   class="
     grid sm:grid-cols-1 overflow-y-scroll h-96 sm:h-52 md:h-44 p-0
-    bg-zinc-200 dark:bg-zinc-900 py-2 rounded-md
+    bg-zinc-200 dark:bg-zinc-700 py-2 rounded-md
   "
 >
   <.live_component

--- a/lib/livedj_web/live/sessions/room_live/list.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/list.html.heex
@@ -1,8 +1,8 @@
 <div
   id="lists"
   class="
-    grid sm:grid-cols-1 overflow-y-scroll h-96 sm:h-52 md:h-44 p-0
-    bg-zinc-200 dark:bg-zinc-700 py-2 rounded-md
+    grid sm:grid-cols-1 overflow-y-auto h-96 sm:h-52 md:h-44
+    bg-zinc-200 dark:bg-zinc-700 rounded-md
   "
 >
   <.live_component

--- a/lib/livedj_web/live/sessions/room_live/show.ex
+++ b/lib/livedj_web/live/sessions/room_live/show.ex
@@ -11,30 +11,30 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
 
   @impl true
   def mount(params, _session, socket) do
-    case connected?(socket) do
-      true ->
-        %Room{id: room_id} = room = Sessions.get_room!(params["id"])
-        {:ok, :joined} = Sessions.join_player(room_id)
+    %Room{id: room_id} = room = Sessions.get_room!(params["id"])
 
-        {:ok, _ref} = Presence.track_user(room_id, socket.assigns.current_user)
+    socket =
+      assign(socket,
+        list_lv_id: playlist_liveview_id(),
+        player_container_id: player_container_id(),
+        spinner_id: spinner_id(),
+        backdrop_id: backdrop_id(),
+        start_time_tracker_id: "player-controls-start-time-tracker",
+        end_time_tracker_id: "player-controls-end-time-tracker",
+        time_slider_id: "player-controls-time-slider",
+        form: to_form(%{}),
+        player: nil,
+        room: room,
+        room_url: nil,
+        content_ready: connected?(socket)
+      )
 
-        {:ok,
-         assign(socket,
-           list_lv_id: playlist_liveview_id(),
-           player_container_id: player_container_id(),
-           spinner_id: spinner_id(),
-           backdrop_id: backdrop_id(),
-           start_time_tracker_id: "player-controls-start-time-tracker",
-           end_time_tracker_id: "player-controls-end-time-tracker",
-           time_slider_id: "player-controls-time-slider",
-           form: to_form(%{}),
-           player: nil,
-           room: room
-         )}
-
-      false ->
-        {:ok, socket}
+    if connected?(socket) do
+      {:ok, :joined} = Sessions.join_player(room_id)
+      {:ok, _ref} = Presence.track_user(room_id, socket.assigns.current_user)
     end
+
+    {:ok, socket}
   rescue
     error in SessionRoomError ->
       case error do
@@ -54,25 +54,31 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
 
   @impl true
   def handle_params(%{"id" => _id} = params, _url, socket) do
-    case connected?(socket) do
-      true ->
-        {:noreply,
-         socket
-         |> apply_action(socket.assigns.live_action, params)}
-
-      false ->
-        {:noreply, socket}
-    end
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
   defp apply_action(socket, :show, _params) do
     socket
     |> assign(:page_title, "#{socket.assigns.room.name}")
+    |> assign(:room_url, nil)
+  end
+
+  defp apply_action(socket, :welcome, _params) do
+    room_url = url(~p"/sessions/rooms/#{socket.assigns.room}")
+
+    socket
+    |> assign(:page_title, "#{socket.assigns.room.name}")
+    |> assign(:room_url, room_url)
   end
 
   # ----------------------------------------------------------------------------
   # Client side event handling
   #
+
+  def handle_event("open_share_modal", _params, socket) do
+    {:noreply,
+     push_patch(socket, to: ~p"/sessions/rooms/#{socket.assigns.room}/welcome")}
+  end
 
   def handle_event("on_player_play", _params, socket) do
     # On click event callback

--- a/lib/livedj_web/live/sessions/room_live/show.ex
+++ b/lib/livedj_web/live/sessions/room_live/show.ex
@@ -16,9 +16,9 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
     socket =
       assign(socket,
         list_lv_id: playlist_liveview_id(),
-        player_container_id: player_container_id(),
-        spinner_id: spinner_id(),
-        backdrop_id: backdrop_id(),
+        player_container_id: "player-container",
+        spinner_id: "player-spinner",
+        backdrop_id: "player-backdrop",
         start_time_tracker_id: "player-controls-start-time-tracker",
         end_time_tracker_id: "player-controls-end-time-tracker",
         time_slider_id: "player-controls-time-slider",
@@ -109,24 +109,25 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
 
   def handle_event("on_player_container_mount", _params, socket) do
     socket =
-      if connected?(socket),
-        do:
-          push_event(socket, "on_container_mounted", %{
-            backdrop_id: socket.assigns.backdrop_id,
-            player_container_id: socket.assigns.player_container_id,
-            spinner_id: socket.assigns.spinner_id,
-            start_time_tracker_id: socket.assigns.start_time_tracker_id,
-            end_time_tracker_id: socket.assigns.end_time_tracker_id,
-            time_slider_id: socket.assigns.time_slider_id
-          }),
-        else: socket
+      if connected?(socket) and is_nil(socket.assigns.player) do
+        push_event(socket, "on_container_mounted", %{
+          backdrop_id: socket.assigns.backdrop_id,
+          player_container_id: socket.assigns.player_container_id,
+          spinner_id: socket.assigns.spinner_id,
+          start_time_tracker_id: socket.assigns.start_time_tracker_id,
+          end_time_tracker_id: socket.assigns.end_time_tracker_id,
+          time_slider_id: socket.assigns.time_slider_id
+        })
+      else
+        socket
+      end
 
     {:noreply, socket}
   end
 
   def handle_event("on_player_loaded", _params, socket) do
     socket =
-      if connected?(socket) do
+      if connected?(socket) and is_nil(socket.assigns.player) do
         {:ok, %Sessions.Player{} = player} =
           Sessions.get_player(socket.assigns.room.id)
 
@@ -209,7 +210,4 @@ defmodule LivedjWeb.Sessions.RoomLive.Show do
   defp assign_player(socket, player), do: assign(socket, :player, player)
 
   defp playlist_liveview_id, do: "playlist-lv-#{Ecto.UUID.generate()}"
-  defp player_container_id, do: "player-container-#{Ecto.UUID.generate()}"
-  defp spinner_id, do: "spinner-#{Ecto.UUID.generate()}"
-  defp backdrop_id, do: "backdrop-#{Ecto.UUID.generate()}"
 end

--- a/lib/livedj_web/live/sessions/room_live/show.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/show.html.heex
@@ -1,80 +1,10 @@
-<.modal
-  :if={@live_action == :welcome}
-  id="welcome-modal"
-  show
-  on_cancel={JS.patch(~p"/sessions/rooms/#{@room}")}
->
-  <.header>
-    <%= gettext("Room ready to share!") %>
-    <:subtitle>
-      <%= gettext("Share the link below with your friends so they can join") %>
-    </:subtitle>
-  </.header>
-
-  <div class="mt-6 flex flex-col gap-3">
-    <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100 text-center">
-      <%= @room.name %>
-    </p>
-    <div class="flex items-center gap-2 rounded-lg bg-zinc-100 dark:bg-zinc-800 px-4 py-3">
-      <span class="flex-1 truncate text-sm text-zinc-700 dark:text-zinc-300 font-mono select-all">
-        <%= @room_url %>
-      </span>
-      <button
-        phx-hook="Clipboard"
-        id="copy-room-url"
-        data-copy-text={@room_url}
-        class="
-          shrink-0 rounded-md px-3 py-1.5 text-xs font-semibold
-          bg-zinc-900 dark:bg-zinc-100
-          text-zinc-50 dark:text-zinc-900
-          hover:bg-zinc-700 dark:hover:bg-zinc-300
-          transition-colors duration-150
-        "
-      >
-        <%= gettext("Copy") %>
-      </button>
-    </div>
-  </div>
-
-  <div class="mt-6 flex justify-end">
-    <.link patch={~p"/sessions/rooms/#{@room}"}>
-      <.button>
-        <%= gettext("Enter room") %>
-      </.button>
-    </.link>
-  </div>
-</.modal>
-
 <%= if @content_ready do %>
-  <div id="room-content" phx-update="ignore" class="h-full my-2">
-    <div
-      id="video-player-hook"
-      phx-hook="Youtube"
-      phx-mounted={JS.push("on_player_container_mount")}
-      phx-update="ignore"
-      class="mx-1 w-[98%] h-72 relative flex"
-    >
-      <%= live_render(@socket, LivedjWeb.PlayerLiveView,
-        id: "player-lv-#{@player_container_id}",
-        session: %{"player_id" => @player_container_id},
-        container: {:div, class: "w-full"},
-        sticky: true
-      ) %>
-
-      <div id={@backdrop_id} class="absolute w-full h-full bg-black rounded-lg">
-        <canvas
-          id={@spinner_id}
-          class="hidden absolute inset-0 w-full h-full rounded-lg"
-        />
-      </div>
-    </div>
-    <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 py-2 my-2 mx-1">
-      <%= live_render(
-        @socket,
-        LivedjWeb.Sessions.RoomLive.List,
-        id: @list_lv_id,
-        sticky: true
-      ) %>
-    </div>
+  <div class="border-t-[1px] border-zinc-200 dark:border-zinc-800 py-2 my-2 mx-1">
+    <%= live_render(
+      @socket,
+      LivedjWeb.Sessions.RoomLive.List,
+      id: @list_lv_id,
+      sticky: true
+    ) %>
   </div>
 <% end %>

--- a/lib/livedj_web/live/sessions/room_live/show.html.heex
+++ b/lib/livedj_web/live/sessions/room_live/show.html.heex
@@ -1,5 +1,52 @@
-<%= if connected?(@socket) do %>
-  <div class="h-full my-2">
+<.modal
+  :if={@live_action == :welcome}
+  id="welcome-modal"
+  show
+  on_cancel={JS.patch(~p"/sessions/rooms/#{@room}")}
+>
+  <.header>
+    <%= gettext("Room ready to share!") %>
+    <:subtitle>
+      <%= gettext("Share the link below with your friends so they can join") %>
+    </:subtitle>
+  </.header>
+
+  <div class="mt-6 flex flex-col gap-3">
+    <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100 text-center">
+      <%= @room.name %>
+    </p>
+    <div class="flex items-center gap-2 rounded-lg bg-zinc-100 dark:bg-zinc-800 px-4 py-3">
+      <span class="flex-1 truncate text-sm text-zinc-700 dark:text-zinc-300 font-mono select-all">
+        <%= @room_url %>
+      </span>
+      <button
+        phx-hook="Clipboard"
+        id="copy-room-url"
+        data-copy-text={@room_url}
+        class="
+          shrink-0 rounded-md px-3 py-1.5 text-xs font-semibold
+          bg-zinc-900 dark:bg-zinc-100
+          text-zinc-50 dark:text-zinc-900
+          hover:bg-zinc-700 dark:hover:bg-zinc-300
+          transition-colors duration-150
+        "
+      >
+        <%= gettext("Copy") %>
+      </button>
+    </div>
+  </div>
+
+  <div class="mt-6 flex justify-end">
+    <.link patch={~p"/sessions/rooms/#{@room}"}>
+      <.button>
+        <%= gettext("Enter room") %>
+      </.button>
+    </.link>
+  </div>
+</.modal>
+
+<%= if @content_ready do %>
+  <div id="room-content" phx-update="ignore" class="h-full my-2">
     <div
       id="video-player-hook"
       phx-hook="Youtube"

--- a/lib/livedj_web/router.ex
+++ b/lib/livedj_web/router.ex
@@ -32,6 +32,7 @@ defmodule LivedjWeb.Router do
         live "/rooms", RoomLive.Index, :index
         live "/rooms/new", RoomLive.Index, :new
         live "/rooms/:id", RoomLive.Show, :show
+        live "/rooms/:id/welcome", RoomLive.Show, :welcome
       end
     end
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -282,7 +282,7 @@ msgstr ""
 
 #: lib/livedj_web/live/sessions/room_live/index.html.heex:3
 #, elixir-autogen, elixir-format
-msgid "Playing now..."
+msgid "Public rooms
 msgstr ""
 
 #: lib/livedj_web/components/layouts/root.html.heex:48

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -282,7 +282,7 @@ msgstr ""
 
 #: lib/livedj_web/live/sessions/room_live/index.html.heex:3
 #, elixir-autogen, elixir-format
-msgid "Playing now..."
+msgid "Public rooms"
 msgstr ""
 
 #: lib/livedj_web/components/layouts/root.html.heex:48

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -282,7 +282,7 @@ msgstr "Salir"
 
 #: lib/livedj_web/live/sessions/room_live/index.html.heex:3
 #, elixir-autogen, elixir-format
-msgid "Playing now..."
+msgid "Salas públicas"
 msgstr "Sonando ahora..."
 
 #: lib/livedj_web/components/layouts/root.html.heex:48

--- a/test/livedj/sessions_test.exs
+++ b/test/livedj/sessions_test.exs
@@ -27,7 +27,7 @@ defmodule Livedj.SessionsTest do
 
       assert {:ok, %Room{} = room} = Sessions.create_room(valid_attrs)
       assert room.name == "some name"
-      assert room.slug == "some slug"
+      assert {:ok, _} = Ecto.UUID.cast(room.slug)
     end
 
     test "create_room/1 with invalid data returns error changeset" do
@@ -40,7 +40,7 @@ defmodule Livedj.SessionsTest do
 
       assert {:ok, %Room{} = room} = Sessions.update_room(room, update_attrs)
       assert room.name == "some updated name"
-      assert room.slug == "some updated slug"
+      assert {:ok, _} = Ecto.UUID.cast(room.slug)
     end
 
     test "update_room/2 with invalid data returns error changeset" do


### PR DESCRIPTION
## Description

**This PR provides:**

- Shareable room URL: a share button in the session header opens a modal with the room's URL and a one-click copy button
- Room slug auto-generated as a UUID on create (removed from user-facing attrs)
- Persistent volume: level and mute state survive page reloads via `localStorage`
- Fix for the YouTube player iframe being destroyed whenever the share modal was toggled
- Redirect to `/sessions/rooms` when clicking the session header logo
- UI polish: updated create-room modal, playlist background colour, header layout, playlist margin

Closes #issue-number

## Type of change

- [x] Bug fix *(non-breaking change which fixes an issue)*
- [x] New feature *(non-breaking change which adds functionality)*

## How Has This Been Tested?

**Instructions:**

1. Create a room and enter the session
2. Click the clipboard icon in the session header — the share modal should open with the room URL
3. Click **Copy** — the button text should briefly read "Copied!" and the URL should be on the clipboard
4. Close the modal — the YouTube player should keep playing without interruption
6. Adjust volume or toggle mute, then reload the page — volume preference should be restored
7. Click the logo in the session header — should navigate to `/sessions/rooms` with a confirmation prompt

**Expected result:** All interactions leave the YouTube player running uninterrupted; volume persists across reloads; share URL is copyable in one click.

## Root cause of the player bug

`show_modal` called `JS.add_class("overflow-hidden", to: "body")`, removing the browser scrollbar on modal open. The page content area widened by ~17 px, the player container (`w-[98%]`) resized, and YouTube briefly blanked during the reflow. Fixed by removing the body scroll-lock (the `fixed inset-0` backdrop already prevents scrolling) and by moving the modal and player out of `@inner_content` into the session layout so live-action changes never trigger a DOM range replacement around the player.

## Checklist

- [x] **I have performed a self-review of my own code**
- [x] **My changes generate no new warnings**
- [x] New and existing unit tests pass locally with my changes
